### PR TITLE
Add custom React Query hooks for API interaction

### DIFF
--- a/src/api/hooks/index.ts
+++ b/src/api/hooks/index.ts
@@ -1,0 +1,3 @@
+export * from './useCreateQueryParamsController.hook'
+export * from './useTypedMutation.hook'
+export * from './useTypedQuery.hook'

--- a/src/api/hooks/useCreateQueryParamsController.hook.ts
+++ b/src/api/hooks/useCreateQueryParamsController.hook.ts
@@ -1,0 +1,72 @@
+import { UseQueryResult } from '@tanstack/react-query'
+import { isEqual } from 'lodash'
+import { useCallback, useRef, useState } from 'react'
+
+/**
+ * Creates unified, type-safe interface for operating query params
+ */
+export const useQueryParamsController = <QueryParamsSchema>(defaultState: QueryParamsSchema) => {
+	/** Query params to be used in actual API request */
+	const [params, setParams] = useState<QueryParamsSchema>(defaultState)
+	/** Data storage intended to collect all updates before calling actual API */
+	const [draft, setDraft] = useState(<QueryParamsSchema>(defaultState))
+
+	const query = useRef(null as UseQueryResult<unknown, unknown> | null)
+
+	const isDraftUpdated = useCallback((keys?: Array<keyof QueryParamsSchema>) => {
+		if (!keys) return isEqual(params, params)
+
+		return keys.some(key => draft[key] !== params[key])
+	}, [draft, params])
+
+	const isCustomQueryFetched = useCallback((keys?: Array<keyof QueryParamsSchema>) => {
+		if (!keys) return isEqual(params, defaultState)
+
+		return keys.some(key => params[key] !== defaultState[key])
+	}, [defaultState, params])
+
+	const handleRefetch = useCallback((refetch: boolean) => {
+		if (!query.current) throw new Error('No associated query')
+
+		if (refetch) {
+			setParams(draft)
+			query.current.refetch()
+		}
+	}, [draft, query])
+
+	const update = useCallback((data: Partial<QueryParamsSchema>, refetch: boolean = false) => {
+		setDraft({ ...draft, ...data })
+
+		handleRefetch(refetch)
+	}, [draft, handleRefetch])
+
+	const reset = useCallback((refetch: boolean = false) => {
+		setParams(defaultState)
+		setDraft(defaultState)
+
+		handleRefetch(refetch)
+
+		return defaultState
+	}, [defaultState, handleRefetch])
+
+	const associateQuery = useCallback((associatedQuery: UseQueryResult<unknown, unknown>) =>
+			query.current = associatedQuery
+		, [])
+
+	const resetDraft = useCallback(() => setDraft(params), [params])
+
+	/** Fetch query with custom params */
+	const apply = useCallback(() => handleRefetch(true), [handleRefetch])
+
+	return {
+		associateQuery,
+		apply,
+		resetDraft,
+		isCustomQueryFetched,
+		isDraftUpdated,
+		draft,
+		get: () => draft,
+		reset,
+		update
+	}
+}

--- a/src/api/hooks/useSorting.hook.ts
+++ b/src/api/hooks/useSorting.hook.ts
@@ -1,0 +1,10 @@
+import { useQueryParamsController } from './useCreateQueryParamsController.hook'
+
+export const useSorting =
+	<SortingParams extends readonly string[]>
+	(
+		params: SortingParams,
+		queryParamsController: ReturnType<typeof useQueryParamsController>
+	) => {
+
+}

--- a/src/api/hooks/useTypedMutation.hook.ts
+++ b/src/api/hooks/useTypedMutation.hook.ts
@@ -1,0 +1,12 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { AxiosResponse } from 'axios'
+import { ApiError_Payload } from 'api/schemas'
+import type { QueryClient } from '@tanstack/query-core'
+
+export const useTypedMutation =
+		<ResponsePayload, Variables>
+		(
+			options: UseMutationOptions<AxiosResponse<ResponsePayload>, AxiosResponse<ApiError_Payload>, Variables>,
+			queryClient ?: QueryClient
+		) =>
+			useMutation < AxiosResponse<ResponsePayload>, AxiosResponse<ApiError_Payload>, Variables> (options, queryClient)

--- a/src/api/hooks/useTypedQuery.hook.ts
+++ b/src/api/hooks/useTypedQuery.hook.ts
@@ -1,0 +1,12 @@
+import { UndefinedInitialDataOptions, useQuery } from '@tanstack/react-query'
+import { AxiosResponse } from 'axios'
+import { ApiError_Payload } from 'api/schemas'
+import type { QueryClient } from '@tanstack/query-core'
+
+export const useTypedQuery =
+	<ResponsePayload>
+	(
+		options: UndefinedInitialDataOptions<AxiosResponse<ResponsePayload>, AxiosResponse<ApiError_Payload>>,
+		queryClient?: QueryClient
+	) =>
+		useQuery<AxiosResponse<ResponsePayload>, AxiosResponse<ApiError_Payload>>(options, queryClient)


### PR DESCRIPTION
Introduce `useTypedMutation`, `useTypedQuery`, `useQueryParamsController`, and `useSorting` hooks to standardize and simplify API requests with type safety and reusable patterns. Also, export these hooks through an index file for streamlined imports.