### PR TITLE
Add interceptors and mock generators for API

### DIFF
--- a/src/api/mocks/database.ts
+++ b/src/api/mocks/database.ts
@@ -1,0 +1,115 @@
+import { Addon, ChallengeRule, ChallengeType, Company, Filter, Group, Transaction, User } from 'api/schemas'
+import {
+	createUserMock,
+	createChallengeTypeMock,
+	createAddonMock,
+	createCompanyMock, createFilterMock, createChallengeRuleMock, createGroupMock, createTransactionMock
+} from 'api/mocks'
+
+const user: {[key in 'withFilter' | 'withGroup' | 'withTransaction']: User} = {
+	withFilter: createUserMock({username: 'User with filter'}),
+	withGroup: createUserMock({username: 'User with group'}),
+	withTransaction: createUserMock({username: 'User with transaction'}),
+}
+
+const users: User[] = [
+	user.withFilter,
+	user.withGroup,
+	user.withTransaction,
+	...[1,2,3,4,5].map((item) => createUserMock({username: `User ${item}`})),
+]
+
+const challenge: {[key in 'withGroup']: ChallengeType} = {
+	withGroup: createChallengeTypeMock({name: 'Challenge with group'}),
+}
+
+const challenges: Addon[] = [
+	challenge.withGroup,
+	...[1,2,3,4,5].map((item) => createAddonMock({name: `Challenge ${item}`})),
+]
+
+const challengeType: {[key in 'withGroup']: ChallengeType} = {
+	withGroup: createChallengeTypeMock({name: 'Challenge type with group'}),
+}
+
+const challengeTypes: ChallengeType[] = [
+	challengeType.withGroup,
+	...[1,2,3,4,5].map((item) => createChallengeTypeMock({name: `Challenge type ${item}`})),
+]
+
+const company: {[key in 'withGroup' | 'withChallengeRule']: Company} = {
+	withGroup: createCompanyMock({name: 'Company with group'}),
+	withChallengeRule: createCompanyMock({name: 'Company with Challenge Rule'}),
+}
+
+const companies: Company[] = [
+	company.withGroup,
+	company.withChallengeRule,
+	...[1,2,3,4,5].map((item) => createCompanyMock({name: `Company ${item}`})),
+]
+
+const filter: {[key in 'withUser']: Filter} = {
+	withUser: createFilterMock({name: 'Filter with group'}),
+}
+
+const filters: Filter[] = [
+	filter.withUser,
+	...[1,2,3,4,5].map((item) => createFilterMock({name: `Filter ${item}`})),
+]
+
+const challengeRule: {[key in 'withCompany']: ChallengeRule} = {
+	withCompany: createChallengeRuleMock({description: 'Challenge Rule with company'}),
+}
+
+const challengeRules: ChallengeRule[] = [
+	challengeRule.withCompany,
+	...[1,2,3,4,5].map((item) => createChallengeRuleMock({description: `Challenge Rule ${item}`})),
+]
+
+const group: {[key in 'withUser' | 'withCompany' | 'withChallenge' | 'withChallengeType']: Group} = {
+	withUser: createGroupMock({name: 'Group with group'}),
+	withCompany: createGroupMock({name: 'Group with group'}),
+	withChallenge: createGroupMock({name: 'Group with group'}),
+	withChallengeType: createGroupMock({name: 'Group with group'}),
+}
+
+const groups: Group[] = [
+	group.withUser,
+	group.withCompany,
+	group.withChallenge,
+	group.withChallengeType,
+	...[1,2,3,4,5].map((item) => createGroupMock({name: `Group ${item}`})),
+]
+
+const transaction: {[key in 'withUser' | 'withGroup']: Transaction} = {
+	withUser: createTransactionMock({user: users[0].id}),
+	withGroup: createTransactionMock({group: groups[0].id}),
+}
+
+const transactions: Transaction[] = [
+	transaction.withUser,
+	transaction.withGroup,
+	...[1,2,3,4,5].map(() => createTransactionMock()),
+]
+
+interface Database {
+	challenges: Addon[]
+	challengeRules: ChallengeRule[]
+	challengeTypes: ChallengeType[]
+	companies: Company[]
+	filters: Filter[]
+	groups: Group[]
+	transactions: Transaction[]
+	users: User[]
+}
+
+export const database: Database = {
+	challenges,
+	challengeRules,
+	challengeTypes,
+	companies,
+	filters,
+	groups,
+	transactions,
+	users,
+}

--- a/src/api/mocks/generators/apiKey.generator.ts
+++ b/src/api/mocks/generators/apiKey.generator.ts
@@ -1,0 +1,8 @@
+import { ApiKey } from 'api/schemas'
+
+export const createApiKeyMock: (filter?: Partial<Omit<ApiKey, 'id'>>) => ApiKey = (apiKey) => ({
+	id: crypto.randomUUID(),
+	name: apiKey?.name ?? "Your new api key",
+	is_active: apiKey?.is_active ?? true,
+	created_at: apiKey?.created_at ?? new Date().toISOString(),
+})

--- a/src/api/mocks/generators/challenge-mock.generator.ts
+++ b/src/api/mocks/generators/challenge-mock.generator.ts
@@ -1,0 +1,7 @@
+import { Addon } from 'api/schemas'
+
+export const createAddonMock: (addon?: Partial<Addon>) => Addon = (addon) => ({
+	id: addon?.id ?? crypto.randomUUID(),
+	name: addon?.name ?? "Your new addon",
+	description: addon?.description ?? 'With a detailed description'
+})

--- a/src/api/mocks/generators/challenge-rule.generator.ts
+++ b/src/api/mocks/generators/challenge-rule.generator.ts
@@ -1,0 +1,8 @@
+import { ChallengeRule } from 'api/schemas'
+
+export const createChallengeRuleMock: (challengeRule?: Partial<ChallengeRule>) => ChallengeRule = (challengeRule) => ({
+	id: challengeRule?.id ?? crypto.randomUUID(),
+	companyId: crypto.randomUUID(),
+	description: challengeRule?.description ?? "Your new challenge rule description",
+	created_at: new Date().toISOString(),
+})

--- a/src/api/mocks/generators/challenge-type.generator.ts
+++ b/src/api/mocks/generators/challenge-type.generator.ts
@@ -1,0 +1,8 @@
+import { ChallengeType } from 'api/schemas'
+
+export const createChallengeTypeMock: (challengeType?: Partial<Omit<ChallengeType, 'id'>>) => ChallengeType = (challengeType) => ({
+	id: crypto.randomUUID(),
+	name: challengeType?.name ?? "Your new challenge type",
+	companyId: crypto.randomUUID(),
+	description: challengeType?.description ?? "Your new challenge type description",
+})

--- a/src/api/mocks/generators/company-mock.generator.ts
+++ b/src/api/mocks/generators/company-mock.generator.ts
@@ -1,0 +1,9 @@
+import { Company } from 'api/schemas'
+
+export const createCompanyMock: (company?: Partial<Omit<Company, 'id'>>) => Company = (company) => ({
+	id: crypto.randomUUID(),
+	name: company?.name ?? "Your new company",
+	description: company?.description ?? "Your new company description",
+	rules: [],
+	created_at: new Date().toISOString(),
+})

--- a/src/api/mocks/generators/filter.generator.ts
+++ b/src/api/mocks/generators/filter.generator.ts
@@ -1,0 +1,8 @@
+import { Filter } from 'api/schemas'
+
+export const createFilterMock: (filter?: Partial<Omit<Filter, 'id'>>) => Filter = (filter) => ({
+	id: crypto.randomUUID(),
+	name: filter?.name ?? "Your new filter",
+	user_id: crypto.randomUUID(),
+	filters: 'filter sting',
+})

--- a/src/api/mocks/generators/group-mock.generator.ts
+++ b/src/api/mocks/generators/group-mock.generator.ts
@@ -1,0 +1,16 @@
+import { createChallengeTypeMock, createCompanyMock } from 'api/mocks'
+import { Group } from 'api/schemas'
+
+export const createGroupMock: (challenge?: Partial<Omit<Group, 'id'>>) => Group = (group) => ({
+	id: crypto.randomUUID(),
+	name: group?.name ?? "Your new group",
+	user: group?.user ?? crypto.randomUUID(),
+	company: group?.company ?? createCompanyMock(),
+	challenge_type: group?.challenge_type ?? createChallengeTypeMock(),
+	addons: group?.addons ?? [],
+	balance: group?.balance ?? 12345,
+	is_archived: group?.is_archived ?? false,
+})
+
+export const createGroupsListMock: (length: number) => Group[] =
+	(length = 5) => Array.from({ length }, (_, index) => createGroupMock({ name: `Group ${index + 1}` }))

--- a/src/api/mocks/generators/transaction-mock.generator.ts
+++ b/src/api/mocks/generators/transaction-mock.generator.ts
@@ -1,0 +1,13 @@
+import { Transaction, TRANSACTION_TYPE } from 'api/schemas'
+
+export const createTransactionMock: (transaction?: Partial<Omit<Transaction, 'id'>>) => Transaction = (transaction) => ({
+	id: crypto.randomUUID(),
+	group: transaction?.group ?? crypto.randomUUID(),
+	user: transaction?.user ?? crypto.randomUUID(),
+	date: transaction?.date ?? new Date().toISOString(),
+	investment: transaction?.investment ?? 100,
+	commission: transaction?.commission ?? 10,
+	profit: transaction?.profit ?? 56,
+	type: transaction?.type ?? TRANSACTION_TYPE.BUY,
+	created_at: transaction?.created_at ?? new Date().toISOString(),
+})

--- a/src/api/mocks/generators/user-mock.generator.ts
+++ b/src/api/mocks/generators/user-mock.generator.ts
@@ -1,0 +1,8 @@
+import { User } from 'api/schemas'
+
+export const createUserMock: (user?: Partial<Omit<User, 'id'>>) => User = (user) => ({
+	id: crypto.randomUUID(),
+	username: user?.username ?? "Your new group",
+	password: user?.password ?? '1!2@3#aA',
+	email: user?.email ?? crypto.randomUUID(),
+})

--- a/src/api/mocks/index.ts
+++ b/src/api/mocks/index.ts
@@ -1,0 +1,10 @@
+// Generators
+export * from './generators/apiKey.generator'
+export * from './generators/challenge-mock.generator'
+export * from './generators/challenge-rule.generator'
+export * from './generators/challenge-type.generator'
+export * from './generators/company-mock.generator'
+export * from './generators/filter.generator'
+export * from './generators/group-mock.generator'
+export * from './generators/transaction-mock.generator'
+export * from './generators/user-mock.generator'

--- a/src/api/mocks/interceptors/challenge/createChallenge.interceptor.ts
+++ b/src/api/mocks/interceptors/challenge/createChallenge.interceptor.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend } from 'api/constants'
+import { CreateAddon_RequestPayload, createAddonContract, GetAddonById_ResponsePayload } from 'api/contracts'
+import { createAddonMock } from 'api/mocks'
+import { alreadyExist_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = createAddonContract
+
+export const createChallenge_Interceptor =
+	http[method]<never, CreateAddon_RequestPayload>(fakeBackend + route, async ({ request }) => {
+		const data = await request.json()
+
+		const existingEntityIndex = database.challenges.findIndex(item => item.name === data.name)
+
+		if (existingEntityIndex !== -1) return alreadyExist_ErrorResponse('Challenge')
+		else {
+			const newChallenge = createAddonMock(data)
+
+			database.challenges.push(newChallenge)
+
+			return HttpResponse.json<GetAddonById_ResponsePayload>(
+				newChallenge,
+				{ status: responseExample?.status },
+			)
+		}
+	})

--- a/src/api/mocks/interceptors/challenge/deleteChallengeById.interceptor.ts
+++ b/src/api/mocks/interceptors/challenge/deleteChallengeById.interceptor.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetAddonById_RouteParams } from 'api/constants'
+import { deleteAddonByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = deleteAddonByIdContract
+
+export const deleteChallengeById_Interceptor =
+	http[method]<GetAddonById_RouteParams>(fakeBackend + route(), async ({
+																				 params: { addon_id }
+																			 }) => {
+		const indexToDelete = database.challenges.findIndex(item => item.id === addon_id)
+
+		if (indexToDelete >= 0) {
+			database.challenges.splice(indexToDelete, 1)
+
+			return HttpResponse.json(
+				undefined,
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Challenge')
+	})

--- a/src/api/mocks/interceptors/challenge/getChallengeById.interceptor.ts
+++ b/src/api/mocks/interceptors/challenge/getChallengeById.interceptor.ts
@@ -1,0 +1,23 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetAddonById_RouteParams } from 'api/constants'
+import { getAddonByIdContract, GetAddonById_ResponsePayload } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getAddonByIdContract
+
+export const getChallengeById_Interceptor =
+	http[method]<GetAddonById_RouteParams>(fakeBackend + route(), async ({ params: { addon_id } }) => {
+		const indexToRetrieve = database.challenges.findIndex(item => item.id === addon_id)
+
+		if (indexToRetrieve !== -1) {
+			return HttpResponse.json<GetAddonById_ResponsePayload>(
+				database.challenges[indexToRetrieve],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Challenge')
+	})

--- a/src/api/mocks/interceptors/challenge/getChallengesList.interceptor.ts
+++ b/src/api/mocks/interceptors/challenge/getChallengesList.interceptor.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, paginatorExample } from 'api/constants'
+import { getAddonsListContract, GetAddonList_Query, GetAddonList_ResponsePayload } from 'api/contracts'
+import { parseSearchParameters } from 'utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getAddonsListContract
+
+export const getChallengesList_Interceptor =
+	http[method](fakeBackend + route, ({ request }) => {
+		const {
+			limit = paginatorExample.limit,
+			offset = paginatorExample.offset
+		} = parseSearchParameters<GetAddonList_Query>(request.url)
+
+		const data = database.challenges.slice(offset, limit)
+
+		return HttpResponse.json<GetAddonList_ResponsePayload>(
+			{
+				count: data.length,
+				results: data,
+			},
+			{
+				status: responseExample?.status
+			}
+		)
+	})

--- a/src/api/mocks/interceptors/challenge/updateChallenge.interceptor.ts
+++ b/src/api/mocks/interceptors/challenge/updateChallenge.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetAddonById_RouteParams } from 'api/constants'
+import {
+	UpdateAddonById_RequestPayload,
+	UpdateAddonById_ResponsePayload,
+	updateAddonByIdContract
+} from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = updateAddonByIdContract
+
+export const updateChallenge_Interceptor =
+	http[method]<GetAddonById_RouteParams, UpdateAddonById_RequestPayload>(fakeBackend + route(), async ({
+																													 request,
+																													 params: { addon_id }
+																												 }) => {
+		const data = await request.json()
+
+		const indexToUpdate = database.challenges.findIndex(item => item.id === addon_id)
+
+		if (indexToUpdate !== -1) {
+			database.challenges[indexToUpdate] = {
+				...database.challenges[indexToUpdate],
+				...data
+			}
+			return HttpResponse.json<UpdateAddonById_ResponsePayload>(database.challenges[indexToUpdate], {
+				status: responseExample?.status
+			})
+		} else return notFound_ErrorResponse('Challenge')
+	})

--- a/src/api/mocks/interceptors/challengeRule/createChallengeRule.interceptor.ts
+++ b/src/api/mocks/interceptors/challengeRule/createChallengeRule.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend } from 'api/constants'
+import {
+	CreateChallengeRule_RequestPayload,
+	createChallengeRuleContract,
+	GetChallengeRuleById_ResponsePayload
+} from 'api/contracts'
+import { createChallengeRuleMock } from 'api/mocks'
+
+import { database } from 'api/mocks/database'
+import { alreadyExist_ErrorResponse } from 'api/utils'
+
+const { endpoint: { method, route }, responseExample } = createChallengeRuleContract
+
+export const createChallengeRule_Interceptor =
+	http[method]<never, CreateChallengeRule_RequestPayload>(fakeBackend + route, async ({ request }) => {
+		const data = await request.json()
+
+		const existingEntityIndex = database.challengeRules.findIndex(item => item.description === data.description)
+
+		if (existingEntityIndex !== -1) return alreadyExist_ErrorResponse('Challenge rule')
+		else {
+			const newChallengeRule = createChallengeRuleMock(data)
+
+			database.challengeRules.push(newChallengeRule)
+
+			return HttpResponse.json<GetChallengeRuleById_ResponsePayload>(
+				newChallengeRule,
+				{ status: responseExample?.status },
+			)
+		}
+	})

--- a/src/api/mocks/interceptors/challengeRule/deleteChallengeRuleById.interceptor.ts
+++ b/src/api/mocks/interceptors/challengeRule/deleteChallengeRuleById.interceptor.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetChallengeRuleById_RouteParams } from 'api/constants'
+import { deleteChallengeRuleByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = deleteChallengeRuleByIdContract
+
+export const deleteChallengeRuleById_Interceptor =
+	http[method]<GetChallengeRuleById_RouteParams>(fakeBackend + route(), async ({
+																				 params: { challenge_rule_id }
+																			 }) => {
+		const indexToDelete = database.challengeRules.findIndex(item => item.id === challenge_rule_id)
+
+		if (indexToDelete !== -1) {
+			database.challengeRules.splice(indexToDelete, 1)
+
+			return HttpResponse.json(
+				undefined,
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Challenge rule')
+	})

--- a/src/api/mocks/interceptors/challengeRule/getChallengeRuleById.interceptor.ts
+++ b/src/api/mocks/interceptors/challengeRule/getChallengeRuleById.interceptor.ts
@@ -1,0 +1,23 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetChallengeRuleById_RouteParams } from 'api/constants'
+import { getChallengeRuleByIdContract, GetChallengeRuleById_ResponsePayload } from 'api/contracts'
+
+import { database } from 'api/mocks/database'
+import { notFound_ErrorResponse } from 'api/utils'
+
+const { endpoint: { method, route }, responseExample } = getChallengeRuleByIdContract
+
+export const getChallengeRuleById_Interceptor =
+	http[method]<GetChallengeRuleById_RouteParams>(fakeBackend + route(), async ({ params: { challenge_rule_id } }) => {
+		const indexToRetrieve = database.challengeRules.findIndex(item => item.id === challenge_rule_id)
+
+		if (indexToRetrieve !== -1) {
+			return HttpResponse.json<GetChallengeRuleById_ResponsePayload>(
+				database.challengeRules[indexToRetrieve],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Challenge rule')
+	})

--- a/src/api/mocks/interceptors/challengeRule/getChallengeRulesList.interceptor.ts
+++ b/src/api/mocks/interceptors/challengeRule/getChallengeRulesList.interceptor.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, paginatorExample } from 'api/constants'
+import { getChallengeRulesListContract, GetChallengeRulesList_RequestQuery, GetChallengeRulesList_ResponsePayload } from 'api/contracts'
+import { parseSearchParameters } from 'utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getChallengeRulesListContract
+
+export const getChallengeRulesList_Interceptor =
+	http[method](fakeBackend + route, ({ request }) => {
+		const {
+			limit = paginatorExample.limit,
+			offset = paginatorExample.offset
+		} = parseSearchParameters<GetChallengeRulesList_RequestQuery>(request.url)
+
+		const data = database.challengeRules.slice(offset, limit)
+
+		return HttpResponse.json<GetChallengeRulesList_ResponsePayload>(
+			{
+				count: data.length,
+				results: data,
+			},
+			{
+				status: responseExample?.status
+			}
+		)
+	})

--- a/src/api/mocks/interceptors/challengeRule/updateChallengeRule.interceptor.ts
+++ b/src/api/mocks/interceptors/challengeRule/updateChallengeRule.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetChallengeRuleById_RouteParams } from 'api/constants'
+import {
+	UpdateChallengeRuleById_RequestPayload,
+	UpdateChallengeRuleById_ResponsePayload,
+	updateChallengeRuleByIdContract
+} from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = updateChallengeRuleByIdContract
+
+export const updateChallengeRule_Interceptor =
+	http[method]<GetChallengeRuleById_RouteParams, UpdateChallengeRuleById_RequestPayload>(fakeBackend + route(), async ({
+																													 request,
+																													 params: { challenge_rule_id }
+																												 }) => {
+		const data = await request.json()
+
+		const indexToUpdate = database.challenges.findIndex(item => item.id === challenge_rule_id)
+
+		if (indexToUpdate !== -1) {
+			database.challengeRules[indexToUpdate] = {
+				...database.challengeRules[indexToUpdate],
+				...data
+			}
+			return HttpResponse.json<UpdateChallengeRuleById_ResponsePayload>(database.challengeRules[indexToUpdate], {
+				status: responseExample?.status
+			})
+		} else return notFound_ErrorResponse('Challenge rule')
+	})

--- a/src/api/mocks/interceptors/challengeType/createChallengeType.interceptor.ts
+++ b/src/api/mocks/interceptors/challengeType/createChallengeType.interceptor.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend } from 'api/constants'
+import { CreateChallengeType_RequestPayload, createChallengeTypeContract, GetChallengeTypeById_ResponsePayload } from 'api/contracts'
+import { createChallengeTypeMock } from 'api/mocks'
+import { alreadyExist_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = createChallengeTypeContract
+
+export const createChallengeType_Interceptor =
+	http[method]<never, CreateChallengeType_RequestPayload>(fakeBackend + route, async ({ request }) => {
+		const data = await request.json()
+
+		const existingEntityIndex = database.challengeTypes.findIndex(item => item.name === data.name)
+
+		if (existingEntityIndex !== -1) return alreadyExist_ErrorResponse('Challenge')
+		else {
+			const newChallengeType = createChallengeTypeMock(data)
+
+			database.challengeTypes.push(newChallengeType)
+
+			return HttpResponse.json<GetChallengeTypeById_ResponsePayload>(
+				newChallengeType,
+				{ status: responseExample?.status },
+			)
+		}
+	})

--- a/src/api/mocks/interceptors/challengeType/deleteChallengeTypeById.interceptor.ts
+++ b/src/api/mocks/interceptors/challengeType/deleteChallengeTypeById.interceptor.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetChallengeTypeById_RouteParams } from 'api/constants'
+import { deleteChallengeTypeByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = deleteChallengeTypeByIdContract
+
+export const deleteChallengeTypeById_Interceptor =
+	http[method]<GetChallengeTypeById_RouteParams>(fakeBackend + route(), async ({
+																				 params: { challenge_type_id }
+																			 }) => {
+		const indexToDelete = database.challenges.findIndex(item => item.id === challenge_type_id)
+
+		if (indexToDelete !== -1) {
+			database.challengeTypes.splice(indexToDelete, 1)
+
+			return HttpResponse.json(
+				undefined,
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Challenge type')
+	})

--- a/src/api/mocks/interceptors/challengeType/getChallengeTypeById.interceptor.ts
+++ b/src/api/mocks/interceptors/challengeType/getChallengeTypeById.interceptor.ts
@@ -1,0 +1,23 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetChallengeTypeById_RouteParams } from 'api/constants'
+import { getChallengeTypeByIdContract, GetChallengeTypeById_ResponsePayload } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getChallengeTypeByIdContract
+
+export const getChallengeById_Interceptor =
+	http[method]<GetChallengeTypeById_RouteParams>(fakeBackend + route(), async ({ params: { challenge_type_id } }) => {
+		const indexToRetrieve = database.challenges.findIndex(item => item.id === challenge_type_id)
+
+		if (indexToRetrieve !== -1) {
+			return HttpResponse.json<GetChallengeTypeById_ResponsePayload>(
+				database.challengeTypes[indexToRetrieve],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Challenge type')
+	})

--- a/src/api/mocks/interceptors/challengeType/getChallengeTypesList.interceptor.ts
+++ b/src/api/mocks/interceptors/challengeType/getChallengeTypesList.interceptor.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, paginatorExample } from 'api/constants'
+import { getChallengeTypesListContract, GetChallengeTypesList_RequestQuery, GetChallengeTypesList_ResponsePayload } from 'api/contracts'
+import { parseSearchParameters } from 'utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getChallengeTypesListContract
+
+export const getChallengeTypesList_Interceptor =
+	http[method](fakeBackend + route, ({ request }) => {
+		const {
+			limit = paginatorExample.limit,
+			offset = paginatorExample.offset
+		} = parseSearchParameters<GetChallengeTypesList_RequestQuery>(request.url)
+
+		const data = database.challengeTypes.slice(offset, limit)
+
+		return HttpResponse.json<GetChallengeTypesList_ResponsePayload>(
+			{
+				count: data.length,
+				results: data,
+			},
+			{
+				status: responseExample?.status
+			}
+		)
+	})

--- a/src/api/mocks/interceptors/challengeType/updateChallengeType.interceptor.ts
+++ b/src/api/mocks/interceptors/challengeType/updateChallengeType.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetChallengeTypeById_RouteParams } from 'api/constants'
+import {
+	UpdateChallengeTypeById_RequestPayload,
+	UpdateChallengeTypeById_ResponsePayload,
+	updateChallengeTypeByIdContract
+} from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = updateChallengeTypeByIdContract
+
+export const updateChallengeType_Interceptor =
+	http[method]<GetChallengeTypeById_RouteParams, UpdateChallengeTypeById_RequestPayload>(fakeBackend + route(), async ({
+																													 request,
+																													 params: { challenge_type_id }
+																												 }) => {
+		const data = await request.json()
+
+		const indexToUpdate = database.challengeTypes.findIndex(item => item.id === challenge_type_id)
+
+		if (indexToUpdate !== -1) {
+			database.challengeTypes[indexToUpdate] = {
+				...database.challengeTypes[indexToUpdate],
+				...data
+			}
+			return HttpResponse.json<UpdateChallengeTypeById_ResponsePayload>(database.challengeTypes[indexToUpdate], {
+				status: responseExample?.status
+			})
+		} else return notFound_ErrorResponse('Challenge type')
+	})

--- a/src/api/mocks/interceptors/company/createCompany.interceptor.ts
+++ b/src/api/mocks/interceptors/company/createCompany.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend } from 'api/constants'
+import {
+	CreateCompany_RequestPayload,
+	createCompanyContract,
+	GetCompanyById_ResponsePayload
+} from 'api/contracts'
+import { createCompanyMock } from 'api/mocks'
+import { alreadyExist_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = createCompanyContract
+
+export const createCompany_Interceptor =
+	http[method]<never, CreateCompany_RequestPayload>(fakeBackend + route, async ({ request }) => {
+		const data = await request.json()
+
+		const existingEntityIndex = database.companies.findIndex(item => item.name === data.name)
+
+		if (existingEntityIndex !== -1) return alreadyExist_ErrorResponse('Company')
+		else {
+			const newCompany = createCompanyMock(data)
+
+			database.companies.push(newCompany)
+
+			return HttpResponse.json<GetCompanyById_ResponsePayload>(
+				newCompany,
+				{ status: responseExample?.status },
+			)
+		}
+	})

--- a/src/api/mocks/interceptors/company/deleteCompanyById.interceptor.ts
+++ b/src/api/mocks/interceptors/company/deleteCompanyById.interceptor.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetCompanyById_RouteParams } from 'api/constants'
+import { deleteCompanyByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = deleteCompanyByIdContract
+
+export const deleteCompanyById_Interceptor =
+	http[method]<GetCompanyById_RouteParams>(fakeBackend + route(), async ({
+																					 params: { company_id }
+																				 }) => {
+		const indexToDelete = database.companies.findIndex(item => item.id === company_id)
+
+		if (indexToDelete >= 0) {
+			database.companies.splice(indexToDelete, 1)
+
+			return HttpResponse.json(
+				undefined,
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Company')
+	})

--- a/src/api/mocks/interceptors/company/getCompaniesList.interceptor.ts
+++ b/src/api/mocks/interceptors/company/getCompaniesList.interceptor.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, paginatorExample } from 'api/constants'
+import { getCompaniesListContract, GetCompaniesList_RequestQuery, GetCompaniesList_ResponsePayload } from 'api/contracts'
+import { parseSearchParameters } from 'utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getCompaniesListContract
+
+export const getCompaniesList_Interceptor =
+	http[method](fakeBackend + route, ({ request }) => {
+		const {
+			limit = paginatorExample.limit,
+			offset = paginatorExample.offset
+		} = parseSearchParameters<GetCompaniesList_RequestQuery>(request.url)
+
+		const data = database.companies.slice(offset, limit)
+
+		return HttpResponse.json<GetCompaniesList_ResponsePayload>(
+			{
+				count: data.length,
+				results: data,
+			},
+			{
+				status: responseExample?.status
+			}
+		)
+	})

--- a/src/api/mocks/interceptors/company/getCompanyById.interceptor.ts
+++ b/src/api/mocks/interceptors/company/getCompanyById.interceptor.ts
@@ -1,0 +1,23 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetCompanyById_RouteParams } from 'api/constants'
+import { GetCompanyById_ResponsePayload, getCompanyByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getCompanyByIdContract
+
+export const getCompanyById_Interceptor =
+	http[method]<GetCompanyById_RouteParams>(fakeBackend + route(), async ({ params: { company_id } }) => {
+		const indexToRetrieve = database.companies.findIndex(item => item.id === company_id)
+
+		if (indexToRetrieve !== -1) {
+			return HttpResponse.json<GetCompanyById_ResponsePayload>(
+				database.companies[indexToRetrieve],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Company')
+	})

--- a/src/api/mocks/interceptors/company/updateCompanyById.interceptor.ts
+++ b/src/api/mocks/interceptors/company/updateCompanyById.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetCompanyById_RouteParams } from 'api/constants'
+import { updateCompanyByIdContract, UpdateCompanyById_RequestPayload, UpdateCompanyById_ResponsePayload } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = updateCompanyByIdContract
+
+export const updateCompanyById_Interceptor =
+	http[method]<GetCompanyById_RouteParams, UpdateCompanyById_RequestPayload>(fakeBackend + route(), async ({
+																					 params: { company_id },
+																					 request
+																				 }) => {
+		const data = await request.json()
+
+		const indexToUpdate = database.companies.findIndex(item => item.id === company_id)
+
+		if (indexToUpdate !== -1) {
+			database.companies[indexToUpdate] = {
+				...database.companies[indexToUpdate],
+				...data
+			}
+
+			return HttpResponse.json<UpdateCompanyById_ResponsePayload>(
+				database.companies[indexToUpdate],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Company')
+	})

--- a/src/api/mocks/interceptors/filter/createFilter.interceptor.ts
+++ b/src/api/mocks/interceptors/filter/createFilter.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend } from 'api/constants'
+import {
+	CreateFilter_RequestPayload,
+	createFilterContract,
+	GetFilterById_ResponsePayload
+} from 'api/contracts'
+import { createFilterMock } from 'api/mocks'
+import { alreadyExist_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = createFilterContract
+
+export const createFilter_Interceptor =
+	http[method]<never, CreateFilter_RequestPayload>(fakeBackend + route, async ({ request }) => {
+		const data = await request.json()
+
+		const existingEntityIndex = database.filters.findIndex(item => item.name === data.name)
+
+		if (existingEntityIndex !== -1) return alreadyExist_ErrorResponse('Filter')
+		else {
+			const newFilter = createFilterMock(data)
+
+			database.filters.push(newFilter)
+
+			return HttpResponse.json<GetFilterById_ResponsePayload>(
+				newFilter,
+				{ status: responseExample?.status },
+			)
+		}
+	})

--- a/src/api/mocks/interceptors/filter/deleteFilterById.interceptor.ts
+++ b/src/api/mocks/interceptors/filter/deleteFilterById.interceptor.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetFilterById_RouteParams } from 'api/constants'
+import { deleteFilterByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = deleteFilterByIdContract
+
+export const deleteFilterById_Interceptor =
+	http[method]<GetFilterById_RouteParams>(fakeBackend + route(), async ({
+																					 params: { filter_id }
+																				 }) => {
+		const indexToDelete = database.filters.findIndex(item => item.id === filter_id)
+
+		if (indexToDelete !== -1) {
+			database.filters.splice(indexToDelete, 1)
+
+			return HttpResponse.json(
+				undefined,
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Filter')
+	})

--- a/src/api/mocks/interceptors/filter/getFilterById.interceptor.ts
+++ b/src/api/mocks/interceptors/filter/getFilterById.interceptor.ts
@@ -1,0 +1,23 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetFilterById_RouteParams } from 'api/constants'
+import { GetFilterById_ResponsePayload, getFilterByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getFilterByIdContract
+
+export const getFilterById_Interceptor =
+	http[method]<GetFilterById_RouteParams>(fakeBackend + route(), async ({ params: { filter_id } }) => {
+		const indexToRetrieve = database.companies.findIndex(item => item.id === filter_id)
+
+		if (indexToRetrieve !== -1) {
+			return HttpResponse.json<GetFilterById_ResponsePayload>(
+				database.filters[indexToRetrieve],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Filter')
+	})

--- a/src/api/mocks/interceptors/filter/getFiltersList.interceptor.ts
+++ b/src/api/mocks/interceptors/filter/getFiltersList.interceptor.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, paginatorExample } from 'api/constants'
+import { getFiltersListContract, GetFiltersList_RequestQuery, GetFiltersList_ResponsePayload } from 'api/contracts'
+import { parseSearchParameters } from 'utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getFiltersListContract
+
+export const getFiltersList_Interceptor =
+	http[method](fakeBackend + route, ({ request }) => {
+		const {
+			limit = paginatorExample.limit,
+			offset = paginatorExample.offset
+		} = parseSearchParameters<GetFiltersList_RequestQuery>(request.url)
+
+		const data = database.filters.slice(offset, limit)
+
+		return HttpResponse.json<GetFiltersList_ResponsePayload>(
+			{
+				count: data.length,
+				results: data,
+			},
+			{
+				status: responseExample?.status
+			}
+		)
+	})

--- a/src/api/mocks/interceptors/filter/updateFilterById.interceptor.ts
+++ b/src/api/mocks/interceptors/filter/updateFilterById.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetFilterById_RouteParams } from 'api/constants'
+import { updateFilterByIdContract, UpdateFilterById_RequestPayload, UpdateFilterById_ResponsePayload } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = updateFilterByIdContract
+
+export const updateFilterById_Interceptor =
+	http[method]<GetFilterById_RouteParams, UpdateFilterById_RequestPayload>(fakeBackend + route(), async ({
+																					 params: { filter_id },
+																					 request
+																				 }) => {
+		const data = await request.json()
+
+		const indexToUpdate = database.companies.findIndex(item => item.id === filter_id)
+
+		if (indexToUpdate !== -1) {
+			database.companies[indexToUpdate] = {
+				...database.companies[indexToUpdate],
+				...data
+			}
+
+			return HttpResponse.json<UpdateFilterById_ResponsePayload>(
+				database.filters[indexToUpdate],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Filter')
+	})

--- a/src/api/mocks/interceptors/group/createGroup.interceptor.ts
+++ b/src/api/mocks/interceptors/group/createGroup.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend } from 'api/constants'
+import {
+	CreateGroup_RequestPayload,
+	createGroupContract,
+	GetGroupById_ResponsePayload
+} from 'api/contracts'
+import { createGroupMock } from 'api/mocks'
+import { alreadyExist_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = createGroupContract
+
+export const createGroup_Interceptor =
+	http[method]<never, CreateGroup_RequestPayload>(fakeBackend + route, async ({ request }) => {
+		const data = await request.json()
+
+		const existingEntityIndex = database.groups.findIndex(item => item.name === data.name)
+
+		if (existingEntityIndex !== -1) return alreadyExist_ErrorResponse('Group')
+		else {
+			const newGroup = createGroupMock()
+
+			database.groups.push(newGroup)
+
+			return HttpResponse.json<GetGroupById_ResponsePayload>(
+				newGroup,
+				{ status: responseExample?.status },
+			)
+		}
+	})

--- a/src/api/mocks/interceptors/group/deleteGroupById.interceptor.ts
+++ b/src/api/mocks/interceptors/group/deleteGroupById.interceptor.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetGroupById_RouteParams } from 'api/constants'
+import { deleteGroupByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = deleteGroupByIdContract
+
+export const deleteGroupById_Interceptor =
+	http[method]<GetGroupById_RouteParams>(fakeBackend + route(), async ({
+																					 params: { group_id }
+																				 }) => {
+		const indexToDelete = database.groups.findIndex(item => item.id === group_id)
+
+		if (indexToDelete >= 0) {
+			database.groups.splice(indexToDelete, 1)
+
+			return HttpResponse.json(
+				undefined,
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Group')
+	})

--- a/src/api/mocks/interceptors/group/getGroupById.interceptor.ts
+++ b/src/api/mocks/interceptors/group/getGroupById.interceptor.ts
@@ -1,0 +1,23 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetGroupById_RouteParams } from 'api/constants'
+import { GetGroupById_ResponsePayload, getGroupByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getGroupByIdContract
+
+export const getGroupById_Interceptor =
+	http[method]<GetGroupById_RouteParams>(fakeBackend + route(), async ({ params: { group_id } }) => {
+		const indexToRetrieve = database.companies.findIndex(item => item.id === group_id)
+
+		if (indexToRetrieve !== -1) {
+			return HttpResponse.json<GetGroupById_ResponsePayload>(
+				database.groups[indexToRetrieve],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Group')
+	})

--- a/src/api/mocks/interceptors/group/getGroupsList.interceptor.ts
+++ b/src/api/mocks/interceptors/group/getGroupsList.interceptor.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend , paginatorExample} from 'api/constants'
+import { getGroupsListContract, GetGroupsList_RequestQuery, GetGroupsList_ResponsePayload } from 'api/contracts'
+import { parseSearchParameters } from 'utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getGroupsListContract
+
+export const getGroupsList_Interceptor =
+	http[method](fakeBackend + route, ({ request }) => {
+		const {
+			limit = paginatorExample.limit,
+			offset = paginatorExample.offset
+		} = parseSearchParameters<GetGroupsList_RequestQuery>(request.url)
+
+		const data = database.groups.slice(offset, limit)
+
+		return HttpResponse.json<GetGroupsList_ResponsePayload>(
+			{
+				count: data.length,
+				results: data,
+			},
+			{
+				status: responseExample?.status
+			}
+		)
+	})

--- a/src/api/mocks/interceptors/group/updateGroupById.interceptor.ts
+++ b/src/api/mocks/interceptors/group/updateGroupById.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetGroupById_RouteParams } from 'api/constants'
+import { updateGroupByIdContract, UpdateGroupById_RequestPayload, UpdateGroupById_ResponsePayload } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = updateGroupByIdContract
+
+export const updateGroupById_Interceptor =
+	http[method]<GetGroupById_RouteParams, UpdateGroupById_RequestPayload>(fakeBackend + route(), async ({
+																					 params: { group_id },
+																					 request
+																				 }) => {
+		const data = await request.json()
+
+		const indexToUpdate = database.companies.findIndex(item => item.id === group_id)
+
+		if (indexToUpdate >= 0) {
+			database.companies[indexToUpdate] = {
+				...database.companies[indexToUpdate],
+				...data
+			}
+
+			return HttpResponse.json<UpdateGroupById_ResponsePayload>(
+				database.groups[indexToUpdate],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Group')
+	})

--- a/src/api/mocks/interceptors/index.ts
+++ b/src/api/mocks/interceptors/index.ts
@@ -1,0 +1,47 @@
+// Challenge
+export * from './challenge/createChallenge.interceptor'
+export * from './challenge/deleteChallengeById.interceptor'
+export * from './challenge/getChallengeById.interceptor'
+export * from './challenge/getChallengesList.interceptor'
+export * from './challenge/updateChallenge.interceptor'
+
+// Challenge Rule
+export * from './challengeRule/createChallengeRule.interceptor'
+export * from './challengeRule/deleteChallengeRuleById.interceptor'
+export * from './challengeRule/getChallengeRuleById.interceptor'
+export * from './challengeRule/getChallengeRulesList.interceptor'
+export * from './challengeRule/updateChallengeRule.interceptor'
+
+// Company
+export * from './company/getCompanyById.interceptor'
+export * from './company/getCompaniesList.interceptor'
+export * from './company/createCompany.interceptor'
+export * from './company/deleteCompanyById.interceptor'
+export * from './company/updateCompanyById.interceptor'
+
+// Filter
+export * from './filter/createFilter.interceptor'
+export * from './filter/deleteFilterById.interceptor'
+export * from './filter/getFilterById.interceptor'
+export * from './filter/getFiltersList.interceptor'
+export * from './filter/updateFilterById.interceptor'
+
+// Group
+export * from './group/getGroupById.interceptor'
+export * from './group/getGroupsList.interceptor'
+export * from './group/createGroup.interceptor'
+export * from './group/deleteGroupById.interceptor'
+export * from './group/updateGroupById.interceptor'
+
+// Transaction
+export * from './transaction/getTransactionById.interceptor'
+export * from './transaction/getTransactionsList.interceptor'
+
+// Users
+export * from './user/getUserById.interceptor'
+export * from './user/getUsersList.interceptor'
+export * from './user/createUser.interceptor'
+export * from './user/deleteUserById.interceptor'
+export * from './user/updateUserById.interceptor'
+
+// TODO: 404 generic error with entity mention

--- a/src/api/mocks/interceptors/transaction/getTransactionById.interceptor.ts
+++ b/src/api/mocks/interceptors/transaction/getTransactionById.interceptor.ts
@@ -1,0 +1,23 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetTransactionById_RouteParams } from 'api/constants'
+import { GetTransactionById_ResponsePayload, getTransactionByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getTransactionByIdContract
+
+export const getTransactionById_Interceptor =
+	http[method]<GetTransactionById_RouteParams>(fakeBackend + route(), async ({ params: { transaction_id } }) => {
+		const indexToRetrieve = database.companies.findIndex(item => item.id === transaction_id)
+
+		if (indexToRetrieve !== -1) {
+			return HttpResponse.json<GetTransactionById_ResponsePayload>(
+				database.transactions[indexToRetrieve],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('Transaction')
+	})

--- a/src/api/mocks/interceptors/transaction/getTransactionsList.interceptor.ts
+++ b/src/api/mocks/interceptors/transaction/getTransactionsList.interceptor.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, paginatorExample } from 'api/constants'
+import { getTransactionsListContract, GetTransactionsList_RequestQuery, GetTransactionsList_ResponsePayload } from 'api/contracts'
+import { parseSearchParameters } from 'utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getTransactionsListContract
+
+export const getTransactionsList_Interceptor =
+	http[method](fakeBackend + route, ({ request }) => {
+		const {
+			limit = paginatorExample.limit,
+			offset = paginatorExample.offset
+		} = parseSearchParameters<GetTransactionsList_RequestQuery>(request.url)
+
+		const data = database.transactions.slice(offset, limit)
+
+		return HttpResponse.json<GetTransactionsList_ResponsePayload>(
+			{
+				count: data.length,
+				results: data,
+			},
+			{
+				status: responseExample?.status
+			}
+		)
+	})

--- a/src/api/mocks/interceptors/user/createUser.interceptor.ts
+++ b/src/api/mocks/interceptors/user/createUser.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend } from 'api/constants'
+import {
+	CreateUser_RequestPayload,
+	createUserContract,
+	GetUserById_ResponsePayload
+} from 'api/contracts'
+import { createUserMock } from 'api/mocks'
+import { alreadyExist_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = createUserContract
+
+export const createUser_Interceptor =
+	http[method]<never, CreateUser_RequestPayload>(fakeBackend + route, async ({ request }) => {
+		const data = await request.json()
+
+		const existingEntityIndex = database.users.findIndex(item => item.email === data.email)
+
+		if (existingEntityIndex !== -1) return alreadyExist_ErrorResponse('User', 'email')
+		else {
+			const newUser = createUserMock(data)
+
+			database.users.push(newUser)
+
+			return HttpResponse.json<GetUserById_ResponsePayload>(
+				newUser,
+				{ status: responseExample?.status },
+			)
+		}
+	})

--- a/src/api/mocks/interceptors/user/deleteUserById.interceptor.ts
+++ b/src/api/mocks/interceptors/user/deleteUserById.interceptor.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetUserById_RouteParams } from 'api/constants'
+import { deleteUserByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = deleteUserByIdContract
+
+export const deleteUserById_Interceptor =
+	http[method]<GetUserById_RouteParams>(fakeBackend + route(), async ({
+																					 params: { user_id }
+																				 }) => {
+		const indexToDelete = database.groups.findIndex(item => item.id === user_id)
+
+		if (indexToDelete >= 0) {
+			database.users.splice(indexToDelete, 1)
+
+			return HttpResponse.json(
+				undefined,
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('User')
+	})

--- a/src/api/mocks/interceptors/user/getUserById.interceptor.ts
+++ b/src/api/mocks/interceptors/user/getUserById.interceptor.ts
@@ -1,0 +1,23 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetUserById_RouteParams } from 'api/constants'
+import { GetUserById_ResponsePayload, getUserByIdContract } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getUserByIdContract
+
+export const getUserById_Interceptor =
+	http[method]<GetUserById_RouteParams>(fakeBackend + route(), async ({ params: { user_id } }) => {
+		const indexToRetrieve = database.companies.findIndex(item => item.id === user_id)
+
+		if (indexToRetrieve !== -1) {
+			return HttpResponse.json<GetUserById_ResponsePayload>(
+				database.users[indexToRetrieve],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('User')
+	})

--- a/src/api/mocks/interceptors/user/getUsersList.interceptor.ts
+++ b/src/api/mocks/interceptors/user/getUsersList.interceptor.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, paginatorExample } from 'api/constants'
+import { getUsersListContract, GetUsersList_RequestQuery, GetUsersList_ResponsePayload } from 'api/contracts'
+import { parseSearchParameters } from 'utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = getUsersListContract
+
+export const getUsersList_Interceptor =
+	http[method](fakeBackend + route, ({ request }) => {
+		const {
+			limit = paginatorExample.limit,
+			offset = paginatorExample.offset
+		} = parseSearchParameters<GetUsersList_RequestQuery>(request.url)
+
+		const data = database.users.slice(offset, limit)
+
+		return HttpResponse.json<GetUsersList_ResponsePayload>(
+			{
+				count: data.length,
+				results: data,
+			},
+			{
+				status: responseExample?.status
+			}
+		)
+	})

--- a/src/api/mocks/interceptors/user/updateUserById.interceptor.ts
+++ b/src/api/mocks/interceptors/user/updateUserById.interceptor.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+import { fakeBackend, GetUserById_RouteParams } from 'api/constants'
+import { updateUserByIdContract, UpdateUserById_RequestPayload, UpdateUserById_ResponsePayload } from 'api/contracts'
+import { notFound_ErrorResponse } from 'api/utils'
+
+import { database } from 'api/mocks/database'
+
+const { endpoint: { method, route }, responseExample } = updateUserByIdContract
+
+export const updateUserById_Interceptor =
+	http[method]<GetUserById_RouteParams, UpdateUserById_RequestPayload>(fakeBackend + route(), async ({
+																					 params: { user_id },
+																					 request
+																				 }) => {
+		const data = await request.json()
+
+		const indexToUpdate = database.companies.findIndex(item => item.id === user_id)
+
+		if (indexToUpdate >= 0) {
+			database.users[indexToUpdate] = {
+				...database.users[indexToUpdate],
+				...data
+			}
+
+			return HttpResponse.json<UpdateUserById_ResponsePayload>(
+				database.users[indexToUpdate],
+				{
+					status: responseExample?.status
+				}
+			)
+		} else return notFound_ErrorResponse('User')
+	})

--- a/src/api/mocks/server.ts
+++ b/src/api/mocks/server.ts
@@ -1,0 +1,58 @@
+// import { environmentVariable } from 'configuration/constants'
+// process.env[environmentVariable.addMetaToContracts] = 'enable'
+//
+// import express from 'express'
+// import cors from 'cors';
+// import { setupServer } from 'msw/node'
+//
+// import * as interceptors from 'api/mocks/interceptors'
+// import {
+// 	createUsersListMock,
+// 	createAddonListMock,
+// 	createChallengeRulesListMock,
+// 	createTransactionsListMock,
+// 	createCompaniesListMock,
+// 	createFiltersListMock, createGroupsListMock, createChallengeTypesListMock
+// } from 'api/mocks'
+// import { Addon, ChallengeRule, ChallengeType, Company, Filter, Challenge, Transaction, User } from 'api/schemas'
+//
+// import { fakeBackend } from '../constants'
+//
+//
+// const mockServer = setupServer(...Object.values(interceptors))
+//
+// mockServer.listen({ onUnhandledRequest: 'warn' })
+//
+// const app = express()
+//
+// app.use(cors());
+// app.use(express.json());
+//
+// app.all('*', async (req, res) => {
+//
+// 	const requestHeaders = { ...req.headers };
+//
+// 	const maybeBody =
+// 		req.body && Object.keys(req.body).length > 0
+// 			? JSON.stringify(req.body)
+// 			: undefined;
+//
+// 	const mockResponse = await fetch(fakeBackend + req.originalUrl + '/', {
+// 		method: req.method,
+// 		// headers: requestHeaders,
+// 		body: maybeBody,
+// 	})
+//
+// 	res.status(mockResponse.status)
+// 	mockResponse.headers.forEach((value, key) => {
+// 		res.setHeader(key, value)
+// 	})
+//
+// 	const data = await mockResponse.arrayBuffer()
+// 	res.send(Buffer.from(data))
+// })
+//
+// const port = 4000
+// app.listen(port, () => {
+// 	console.log(`Mock server is running at http://localhost:${port}`)
+// })


### PR DESCRIPTION
Implemented new interceptors for various entities like challenges, challenge rules, transactions, users, and companies. Added mock generators for testing purposes and structured the mock server setup for easier management.