### PR TITLE
Add mutation hooks for API operations

### DIFF
--- a/src/api/mutations/addon/useCreateAddon.mutation.ts
+++ b/src/api/mutations/addon/useCreateAddon.mutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getAddonsListContract,
+	createAddonContract,
+	CreateAddon_RequestPayload,
+	CreateAddon_ResponsePayload
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useCreateAddonMutation = () => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = createAddonContract
+
+	const createAddon = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: CreateAddon_RequestPayload) =>
+				await api[method]<CreateAddon_ResponsePayload>(route, {
+					data,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getAddonsListContract.name] })
+			},
+		})
+
+	return { createAddon }
+}

--- a/src/api/mutations/addon/useDeleteAddon.mutation.ts
+++ b/src/api/mutations/addon/useDeleteAddon.mutation.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { deleteAddonByIdContract, getAddonsListContract } from 'api/contracts'
+import { GetAddonById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useDeleteAddonByIdMutation = () => {
+	const queryClient = useQueryClient()
+	const { name, endpoint: { method, route } } = deleteAddonByIdContract
+
+	const deleteAddon = useMutation({
+			mutationKey: [name],
+			mutationFn: async (routeParams: GetAddonById_RouteParams) => {
+				return await api[method](route(routeParams))
+			},
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getAddonsListContract.name] })
+			}
+		})
+
+	return { deleteAddon }
+}

--- a/src/api/mutations/addon/useUpdateAddon.mutation.ts
+++ b/src/api/mutations/addon/useUpdateAddon.mutation.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getAddonsListContract,
+	updateAddonByIdContract,
+} from 'api/contracts'
+import { GetAddonById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useUpdateAddonByIdMutation = () => {
+	const queryClient = useQueryClient()
+	const { name, endpoint: { method, route } } = updateAddonByIdContract
+
+	const updateAddon = useMutation({
+		mutationKey: [name],
+		mutationFn: async (routeParams: GetAddonById_RouteParams) => {
+			return await api[method](route(routeParams))
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: [getAddonsListContract.name] })
+		}
+	})
+
+	return { updateAddon }
+}

--- a/src/api/mutations/apiKey/useCreateApiKey.mutation.ts
+++ b/src/api/mutations/apiKey/useCreateApiKey.mutation.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getApiKeysListContract,
+	createApiKeyContract,
+	CreateApiKey_RequestPayload,
+	CreateApiKey_ResponsePayload
+} from 'api/contracts'
+import { RequestExtender } from 'api/types/request-hook'
+import { api } from 'configuration'
+import { useToast } from 'configuration/store'
+
+export const useCreateApiKeyMutation = (options: RequestExtender<CreateApiKey_ResponsePayload> = {}) => {
+	const queryClient = useQueryClient()
+	const { showToast } = useToast()
+
+	const {name, endpoint: {method, route}} = createApiKeyContract
+
+	const createApiKey = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: CreateApiKey_RequestPayload) =>
+				await api[method]<CreateApiKey_ResponsePayload>(route, data),
+			onSuccess: () => {
+				if (options.onSuccess) options.onSuccess()
+				showToast({message: `Successfully created api key`, type: 'success'})
+				queryClient.invalidateQueries({ queryKey: [getApiKeysListContract.name] })
+			},
+		})
+
+	return { createApiKey }
+}

--- a/src/api/mutations/apiKey/useDeleteApiKey.mutation.ts
+++ b/src/api/mutations/apiKey/useDeleteApiKey.mutation.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { DeleteApiKeyById_Response, deleteApiKeyByIdContract, getApiKeysListContract } from 'api/contracts'
+import { GetApiKeyById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+import { useToast } from 'configuration/store'
+import { RequestExtender } from 'api/types/request-hook'
+
+export const useDeleteApiKeyByIdMutation = (options: RequestExtender<DeleteApiKeyById_Response>) => {
+	const queryClient = useQueryClient()
+	const { showToast } = useToast()
+
+	const { name, endpoint: { method, route } } = deleteApiKeyByIdContract
+
+	const deleteApiKey = useMutation({
+			mutationKey: [name],
+			mutationFn: async (routeParams: GetApiKeyById_RouteParams) => {
+				return await api[method](route(routeParams))
+			},
+			onSuccess: () => {
+				if (options?.onSuccess) options.onSuccess()
+				showToast({ message: 'API key deleted', type: 'info' })
+				queryClient.invalidateQueries({ queryKey: [getApiKeysListContract.name] })
+			}
+		})
+
+	return { deleteApiKey }
+}

--- a/src/api/mutations/apiKey/useUpdateApiKey.mutation.ts
+++ b/src/api/mutations/apiKey/useUpdateApiKey.mutation.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getApiKeysListContract,
+	updateApiKeyByIdContract,
+} from 'api/contracts'
+import { GetApiKeyById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useUpdateApiKeyByIdMutation = () => {
+	const queryClient = useQueryClient()
+	const { name, endpoint: { method, route } } = updateApiKeyByIdContract
+
+	const updateApiKey = useMutation({
+		mutationKey: [name],
+		mutationFn: async (routeParams: GetApiKeyById_RouteParams) => {
+			return await api[method](route(routeParams))
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: [getApiKeysListContract.name] })
+		}
+	})
+
+	return { updateApiKey }
+}

--- a/src/api/mutations/auth/useChangePassword.mutation.ts
+++ b/src/api/mutations/auth/useChangePassword.mutation.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query'
+
+import {
+	ChangePassword_RequestPayload,
+	ChangePassword_Response,
+	changePasswordContract
+} from 'api/contracts'
+import { RequestExtender } from 'api/types/request-hook'
+import { api } from 'configuration'
+import { useToast } from 'configuration/store'
+
+export const useChangePasswordMutation = ({ onSuccess }: RequestExtender = {}) => {
+	const { name, endpoint: { method, route } } = changePasswordContract
+
+	const { showToast } = useToast()
+
+	const changePassword = useMutation({
+		mutationKey: [name],
+		mutationFn: async (data: ChangePassword_RequestPayload) =>
+			await api[method]<ChangePassword_Response>(route, data),
+		onSuccess: () => {
+			if (onSuccess) onSuccess()
+			showToast({ message: 'Password changed', type: 'success' })
+		},
+	})
+
+	return { changePassword }
+}

--- a/src/api/mutations/auth/useCreateToken.mutation.ts
+++ b/src/api/mutations/auth/useCreateToken.mutation.ts
@@ -1,0 +1,41 @@
+import { useMutation } from '@tanstack/react-query'
+import { AxiosResponse } from 'axios'
+
+import {
+	createTokenContract,
+	CreateToken_RequestPayload,
+	CreateToken_ResponsePayload,
+} from 'api/contracts'
+import { RequestExtender } from 'api/types/request-hook'
+import { api } from 'configuration'
+import { useToast } from 'configuration/store'
+import { useLogin } from 'hooks'
+
+export type CreateTokenMutation_Extender = RequestExtender<CreateToken_ResponsePayload>
+
+export const useCreateTokenMutation = (options: CreateTokenMutation_Extender = {}) => {
+	const {name, endpoint: { method, route}} = createTokenContract
+	const { showToast } = useToast()
+	const { login } = useLogin()
+
+	const { onError } = options
+
+	const createToken = useMutation<AxiosResponse<CreateToken_ResponsePayload>, unknown, CreateToken_RequestPayload>({
+		mutationKey: [name],
+		mutationFn: async (data) =>
+			await api[method](route, data),
+		onError: (e) => {
+			showToast({message: 'Login failed', type: 'error'})
+			if (onError) onError(e)
+		},
+		onSuccess: (data) => {
+			login({
+				user: data.data.user,
+				access: data.data.access,
+				refresh: data.data.refresh,
+			})
+		},
+	})
+
+	return { createToken }
+}

--- a/src/api/mutations/auth/useRemoveTokenFromServer.mutation.ts
+++ b/src/api/mutations/auth/useRemoveTokenFromServer.mutation.ts
@@ -1,0 +1,30 @@
+import { useMutation } from '@tanstack/react-query'
+
+import {
+	removeTokenFromServerContract,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useRemoveTokenFromServer = () => {
+	const {name, endpoint: { method, route}} = removeTokenFromServerContract
+
+	// const { onSuccess, onError } = options
+	// todo ensure calls nextjs server (baseurl)
+
+	const removeTokenFromServer = useMutation({
+		mutationKey: [name],
+		mutationFn: async () =>
+			await api[method](route, {
+				baseURL: window.location.origin
+			}),
+		onError: (e) => {
+			console.log(e)
+		},
+		onSuccess: () => {
+			console.log('sync ok')
+			// onSuccess && onSuccess()
+		},
+	})
+
+	return { removeTokenFromServer }
+}

--- a/src/api/mutations/auth/useResetPassword.mutation.ts
+++ b/src/api/mutations/auth/useResetPassword.mutation.ts
@@ -1,0 +1,22 @@
+import { useMutation } from '@tanstack/react-query'
+
+import {
+	resetPasswordContract,
+	ResetPassword_RequestPayload,
+	ResetPassword_Response,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useResetPasswordMutation = () => {
+	const {name, endpoint: {method, route}} = resetPasswordContract
+
+	const resetPassword = useMutation({
+		mutationKey: [name],
+		mutationFn: async (data: ResetPassword_RequestPayload) =>
+			await api[method]<ResetPassword_Response>(route, {
+				data,
+			}),
+	})
+
+	return { resetPassword }
+}

--- a/src/api/mutations/auth/useRestorePassword.mutation.ts
+++ b/src/api/mutations/auth/useRestorePassword.mutation.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query'
+
+import {
+	RestorePassword_RequestPayload,
+	RestorePassword_Response,
+	restorePasswordContract
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useRestorePasswordMutation = () => {
+	const { name, endpoint: { method, route } } = restorePasswordContract
+
+	const restorePassword = useMutation({
+		mutationKey: [name],
+		mutationFn: async (data: RestorePassword_RequestPayload) =>
+			await api[method]<RestorePassword_Response>(route, data)
+	})
+
+	return { restorePassword }
+}

--- a/src/api/mutations/auth/useSignUp.mutation.ts
+++ b/src/api/mutations/auth/useSignUp.mutation.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query'
+
+import {
+	signUpContract,
+	SignUp_RequestPayload,
+} from 'api/contracts'
+import { RequestExtender } from 'api/types/request-hook'
+import { api } from 'configuration'
+
+export const useSignUpMutation = (options: RequestExtender<undefined> = {}) => {
+	const {name, endpoint: { method, route}} = signUpContract
+
+	const signUp = useMutation({
+		mutationKey: [name],
+		mutationFn: async (data: SignUp_RequestPayload) =>
+			await api[method](route, data),
+		onSuccess: () => {
+			if (options.onSuccess) options.onSuccess()
+		},
+	})
+
+	return { signUp }
+}

--- a/src/api/mutations/auth/useSyncTokenWithServer.mutation.ts
+++ b/src/api/mutations/auth/useSyncTokenWithServer.mutation.ts
@@ -1,0 +1,29 @@
+import { useMutation } from '@tanstack/react-query'
+
+import {
+	syncTokenWithServerContract,
+	SyncTokenWithServer_RequestPayload,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useSyncTokenWithServerMutation = () => {
+	const {name, endpoint: { method, route}} = syncTokenWithServerContract
+
+	// const { onSuccess, onError } = options
+
+	const syncTokenWithServer = useMutation({
+		mutationKey: [name],
+		mutationFn: async (data: SyncTokenWithServer_RequestPayload) =>
+			await api[method](route, {
+				...data,
+			}, {baseURL: window.location.origin,}),
+		onError: (e) => {
+			console.log(e)
+		},
+		onSuccess: () => {
+			// onSuccess && onSuccess()
+		},
+	})
+
+	return { syncTokenWithServer }
+}

--- a/src/api/mutations/auth/useVerifyToken.mutation.ts
+++ b/src/api/mutations/auth/useVerifyToken.mutation.ts
@@ -1,0 +1,30 @@
+import { useMutation } from '@tanstack/react-query'
+import { AxiosResponse } from 'axios'
+
+import {
+	verifyTokenContract,
+	VerifyToken_RequestPayload,
+	VerifyToken_ResponsePayload,
+} from 'api/contracts'
+import { RequestExtender } from 'api/types/request-hook'
+import { api } from 'configuration'
+
+export const useVerifyTokenMutation = (options: RequestExtender<VerifyToken_ResponsePayload>) => {
+	const {name, endpoint: { method, route}} = verifyTokenContract
+
+	const { onSuccess, onError } = options
+
+	const verifyToken = useMutation<AxiosResponse<VerifyToken_ResponsePayload>, unknown, VerifyToken_RequestPayload>({
+		mutationKey: [name],
+		mutationFn: async (data) =>
+			await api[method](route, data),
+		onError: () => {
+			if (onError) onError()
+		},
+		onSuccess: (data) => {
+			if (onSuccess) onSuccess(data)
+		},
+	})
+
+	return { verifyToken }
+}

--- a/src/api/mutations/challengeRule/useCreateChallengeRule.mutation.ts
+++ b/src/api/mutations/challengeRule/useCreateChallengeRule.mutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getChallengeRulesListContract,
+	createChallengeRuleContract,
+	CreateChallengeRule_RequestPayload,
+	CreateChallengeRule_ResponsePayload,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useCreateChallengeRuleMutation = () => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = createChallengeRuleContract
+
+	const createChallengeRule = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: CreateChallengeRule_RequestPayload) =>
+				await api[method]<CreateChallengeRule_ResponsePayload>(route, {
+					data,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getChallengeRulesListContract.name] })
+			},
+		})
+
+	return { createChallengeRule }
+}

--- a/src/api/mutations/challengeRule/useDeleteChallengeRule.mutation.ts
+++ b/src/api/mutations/challengeRule/useDeleteChallengeRule.mutation.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { deleteChallengeRuleByIdContract, getChallengeRulesListContract } from 'api/contracts'
+import { GetChallengeRuleById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useDeleteChallengeRuleByIdMutation = (routeParams: GetChallengeRuleById_RouteParams) => {
+	const queryClient = useQueryClient()
+	const { name, endpoint: { method, route } } = deleteChallengeRuleByIdContract
+
+	const deleteChallengeRule = useMutation({
+		mutationKey: [name],
+		mutationFn: async () =>
+			await api[method](route(routeParams)),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: [getChallengeRulesListContract.name] })
+		}
+	})
+
+	return { deleteChallengeRule }
+}

--- a/src/api/mutations/challengeRule/useUpdateChallengeRule.mutation.ts
+++ b/src/api/mutations/challengeRule/useUpdateChallengeRule.mutation.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getChallengeRulesListContract,
+	updateChallengeRuleByIdContract,
+	UpdateChallengeRuleById_RequestPayload,
+	UpdateChallengeRuleById_ResponsePayload,
+} from 'api/contracts'
+import { GetChallengeRuleById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useUpdateChallengeRuleMutation = (routeParams: GetChallengeRuleById_RouteParams) => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = updateChallengeRuleByIdContract
+
+	const updateChallengeRule = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: UpdateChallengeRuleById_RequestPayload) =>
+				await api[method]<UpdateChallengeRuleById_ResponsePayload>(route(routeParams), {
+					data,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getChallengeRulesListContract.name] })
+			},
+		})
+
+	return { updateChallengeRule }
+}

--- a/src/api/mutations/challengeType/useCreateChallengeRule.mutation.ts
+++ b/src/api/mutations/challengeType/useCreateChallengeRule.mutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getChallengeTypesListContract,
+	createChallengeTypeContract,
+	CreateChallengeType_RequestPayload,
+	CreateChallengeType_ResponsePayload,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useCreateChallengeTypeMutation = () => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = createChallengeTypeContract
+
+	const createChallengeType = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: CreateChallengeType_RequestPayload) =>
+				await api[method]<CreateChallengeType_ResponsePayload>(route, {
+					data,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getChallengeTypesListContract.name] })
+			},
+		})
+
+	return { createChallengeType }
+}

--- a/src/api/mutations/challengeType/useDeleteChallengeRule.mutation.ts
+++ b/src/api/mutations/challengeType/useDeleteChallengeRule.mutation.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { deleteChallengeTypeByIdContract, getChallengeTypesListContract } from 'api/contracts'
+import { GetChallengeTypeById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useDeleteChallengeTypeByIdMutation = (routeParams: GetChallengeTypeById_RouteParams) => {
+	const queryClient = useQueryClient()
+	const { name, endpoint: { method, route } } = deleteChallengeTypeByIdContract
+
+	const deleteChallengeType = useMutation({
+		mutationKey: [name],
+		mutationFn: async () =>
+			await api[method](route(routeParams)),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: [getChallengeTypesListContract.name] })
+		}
+	})
+
+	return { deleteChallengeType }
+}

--- a/src/api/mutations/challengeType/useUpdateChallengeRule.mutation.ts
+++ b/src/api/mutations/challengeType/useUpdateChallengeRule.mutation.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getChallengeTypesListContract,
+	updateChallengeTypeByIdContract,
+	UpdateChallengeTypeById_RequestPayload,
+	UpdateChallengeTypeById_ResponsePayload,
+} from 'api/contracts'
+import { GetChallengeTypeById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useUpdateChallengeTypeMutation = (routeParams: GetChallengeTypeById_RouteParams) => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = updateChallengeTypeByIdContract
+
+	const updateChallengeType = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: UpdateChallengeTypeById_RequestPayload) =>
+				await api[method]<UpdateChallengeTypeById_ResponsePayload>(route(routeParams), {
+					data,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getChallengeTypesListContract.name] })
+			},
+		})
+
+	return { updateChallengeType }
+}

--- a/src/api/mutations/company/useCreateCompany.mutation.ts
+++ b/src/api/mutations/company/useCreateCompany.mutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getCompaniesListContract,
+	createCompanyContract,
+	CreateCompany_RequestPayload,
+	CreateCompany_ResponsePayload,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useCreateCompanyMutation = () => {
+	const queryClient = useQueryClient()
+	const {name, endpoint:{method, route}} = createCompanyContract
+
+	const createCompany = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: CreateCompany_RequestPayload) =>
+				await api[method]<CreateCompany_ResponsePayload>(route, {
+					data,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getCompaniesListContract.name] })
+			},
+		})
+
+	return { createCompany }
+}

--- a/src/api/mutations/company/useDeleteCompany.mutation.ts
+++ b/src/api/mutations/company/useDeleteCompany.mutation.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getCompaniesListContract,
+	deleteCompanyByIdContract,
+
+} from 'api/contracts'
+import { GetCompanyById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useDeleteCompanyByIdMutation = (routeParams: GetCompanyById_RouteParams) => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = deleteCompanyByIdContract
+
+	const deleteCompany = useMutation({
+			mutationKey: [name],
+			mutationFn: async () =>
+				await api[method](route(routeParams)),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getCompaniesListContract.name] })
+			},
+		})
+
+	return { deleteCompany }
+}

--- a/src/api/mutations/company/useUpdateCompany.mutation.ts
+++ b/src/api/mutations/company/useUpdateCompany.mutation.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getCompaniesListContract,
+	updateCompanyByIdContract,
+	UpdateCompanyById_RequestPayload,
+	UpdateCompanyById_ResponsePayload,
+} from 'api/contracts'
+import { api } from 'configuration'
+import { GetCompanyById_RouteParams } from 'api/constants'
+
+export const useUpdateCompanyMutation = (routeParams: GetCompanyById_RouteParams) => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = updateCompanyByIdContract
+
+	const updateCompany = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: UpdateCompanyById_RequestPayload) =>
+				await api[method]<UpdateCompanyById_ResponsePayload>(route(routeParams), {
+					data,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getCompaniesListContract.name] })
+			},
+		})
+
+	return { updateCompany }
+}

--- a/src/api/mutations/filter/useCreateFilter.mutation.ts
+++ b/src/api/mutations/filter/useCreateFilter.mutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getCompaniesListContract,
+	createFilterContract,
+	CreateFilter_RequestPayload,
+	CreateFilter_ResponsePayload,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useCreateFilterMutation = () => {
+	const queryClient = useQueryClient()
+	const {name, endpoint:{method, route}} = createFilterContract
+
+	const createFilter = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: CreateFilter_RequestPayload) =>
+				await api[method]<CreateFilter_ResponsePayload>(route, {
+					data,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getCompaniesListContract.name] })
+			},
+		})
+
+	return { createFilter }
+}

--- a/src/api/mutations/filter/useDeleteFilter.mutation.ts
+++ b/src/api/mutations/filter/useDeleteFilter.mutation.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getCompaniesListContract,
+	deleteFilterByIdContract,
+} from 'api/contracts'
+import { GetFilterById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useDeleteFilterByIdMutation = (routeParams: GetFilterById_RouteParams) => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = deleteFilterByIdContract
+
+	const deleteFilter = useMutation({
+			mutationKey: [name],
+			mutationFn: async () =>
+				await api[method](route(routeParams)),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getCompaniesListContract.name] })
+			},
+		})
+
+	return { deleteFilter }
+}

--- a/src/api/mutations/filter/useUpdateFilter.mutation.ts
+++ b/src/api/mutations/filter/useUpdateFilter.mutation.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getCompaniesListContract,
+	updateFilterByIdContract,
+	UpdateFilterById_RequestPayload,
+	UpdateFilterById_ResponsePayload,
+} from 'api/contracts'
+import { api } from 'configuration'
+import { GetFilterById_RouteParams } from 'api/constants'
+
+export const useUpdateFilterMutation = (routeParams: GetFilterById_RouteParams) => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = updateFilterByIdContract
+
+	const updateFilter = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: UpdateFilterById_RequestPayload) =>
+				await api[method]<UpdateFilterById_ResponsePayload>(route(routeParams), {
+					data,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getCompaniesListContract.name] })
+			},
+		})
+
+	return { updateFilter }
+}

--- a/src/api/mutations/group/useCreateGroup.mutation.ts
+++ b/src/api/mutations/group/useCreateGroup.mutation.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getGroupsListContract,
+	createGroupContract,
+	CreateGroup_RequestPayload,
+	CreateGroup_ResponsePayload,
+} from 'api/contracts'
+import { api } from 'configuration'
+import { RequestExtender } from 'api/types/request-hook'
+
+export const useCreateGroupMutation = (options: RequestExtender) => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = createGroupContract
+
+	const createGroup = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: CreateGroup_RequestPayload) =>
+				await api[method]<CreateGroup_ResponsePayload>(route, data),
+			onSuccess: () => {
+				if (options.onSuccess) options.onSuccess()
+
+				queryClient.invalidateQueries({ queryKey: [getGroupsListContract.name] })
+			},
+		})
+
+	return { createGroup }
+}

--- a/src/api/mutations/group/useDeleteGroup.mutation.ts
+++ b/src/api/mutations/group/useDeleteGroup.mutation.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getGroupsListContract,
+	deleteGroupByIdContract
+} from 'api/contracts'
+import { GetGroupById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+import { useToast } from 'configuration/store'
+import { RequestExtender } from 'api/types/request-hook'
+
+// TODO: Introduce options in mutations
+export const useDeleteGroupByIdMutation = (options: RequestExtender<undefined>) => {
+	const queryClient = useQueryClient()
+	const { name, endpoint: { method, route } } = deleteGroupByIdContract
+	const { showToast } = useToast()
+
+	const { onSuccess, onError } = options
+
+	const deleteGroup = useMutation({
+		mutationKey: [name],
+		mutationFn: async (routeParams: GetGroupById_RouteParams) =>
+			await api[method](route(routeParams)),
+		onSuccess: () => {
+			if (onSuccess) onSuccess()
+
+			showToast({ message: 'Group deleted', type: 'info' })
+			queryClient.invalidateQueries({ queryKey: [getGroupsListContract.name] })
+		},
+		onError: () => {
+			if (onError) onError()
+			showToast({ message: 'Can\'t delete group', type: 'error' })
+		}
+	})
+
+	return { deleteGroup }
+}

--- a/src/api/mutations/group/useUpdateGroup.mutation.ts
+++ b/src/api/mutations/group/useUpdateGroup.mutation.ts
@@ -1,0 +1,34 @@
+import { useQueryClient } from '@tanstack/react-query'
+
+import {
+	getGroupsListContract,
+	updateGroupByIdContract,
+	UpdateGroupById_RequestPayload,
+	UpdateGroupById_ResponsePayload
+} from 'api/contracts'
+import { useTypedMutation } from 'api/hooks'
+import { Id } from 'api/schemas'
+import { api } from 'configuration'
+
+export const useUpdateGroupMutation = () => {
+	const queryClient = useQueryClient()
+	const { name, endpoint: { method, route } } = updateGroupByIdContract
+
+	const updateGroup =
+		useTypedMutation<
+			UpdateGroupById_ResponsePayload,
+			{ id: Id } & UpdateGroupById_RequestPayload
+		>({
+			mutationKey: [name],
+			mutationFn: async ({ id, ...updatedGroup }) =>
+				await api[method](
+					route({ group_id: id }),
+					updatedGroup
+				),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getGroupsListContract.name] })
+			}
+		})
+
+	return { updateGroup }
+}

--- a/src/api/mutations/index.ts
+++ b/src/api/mutations/index.ts
@@ -1,0 +1,53 @@
+// Auth
+export * from './auth/useResetPassword.mutation'
+export * from './auth/useRestorePassword.mutation'
+export * from './auth/useSignUp.mutation'
+export * from './auth/useRemoveTokenFromServer.mutation'
+export * from './auth/useSyncTokenWithServer.mutation'
+export * from './auth/useCreateToken.mutation'
+export * from './auth/useVerifyToken.mutation'
+export * from './auth/useChangePassword.mutation'
+
+// Addon
+export * from './addon/useCreateAddon.mutation'
+export * from './addon/useDeleteAddon.mutation'
+export * from './addon/useUpdateAddon.mutation'
+
+// API key
+export * from './apiKey/useCreateApiKey.mutation'
+export * from './apiKey/useDeleteApiKey.mutation'
+export * from './apiKey/useUpdateApiKey.mutation'
+
+// Challenge Rule
+export * from './challengeRule/useCreateChallengeRule.mutation'
+export * from './challengeRule/useDeleteChallengeRule.mutation'
+export * from './challengeRule/useUpdateChallengeRule.mutation'
+
+// Challenge Type
+export * from './challengeType/useCreateChallengeRule.mutation'
+export * from './challengeType/useDeleteChallengeRule.mutation'
+export * from './challengeType/useUpdateChallengeRule.mutation'
+
+// Company
+export * from './company/useCreateCompany.mutation'
+export * from './company/useDeleteCompany.mutation'
+export * from './company/useUpdateCompany.mutation'
+
+// Filter
+export * from './filter/useCreateFilter.mutation'
+export * from './filter/useDeleteFilter.mutation'
+export * from './filter/useUpdateFilter.mutation'
+
+// Group
+export * from './group/useCreateGroup.mutation'
+export * from './group/useDeleteGroup.mutation'
+export * from './group/useUpdateGroup.mutation'
+
+// Transaction
+export * from './transaction/useAddTransactionToGroup.mutation'
+export * from './transaction/useRemoveTransactionFromGroup.mutation'
+
+// User
+export * from './user/useCreateUser.mutation'
+export * from './user/useDeleteUser.mutation'
+export * from './user/useUpdateUser.mutation'

--- a/src/api/mutations/transaction/useAddTransactionToGroup.mutation.ts
+++ b/src/api/mutations/transaction/useAddTransactionToGroup.mutation.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getTransactionsListContract,
+	addTransactionToGroupContract,
+	AddTransactionToGroup_ResponsePayload,
+} from 'api/contracts'
+import { AddTransactionToGroup_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useAddTransactionToGroupMutation = (params: AddTransactionToGroup_RouteParams) => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = addTransactionToGroupContract
+
+	const addTransactionToGroup = useMutation({
+			mutationKey: [name],
+			mutationFn: async () =>
+				await api[method]<AddTransactionToGroup_ResponsePayload>(route(params)),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getTransactionsListContract.name] })
+			},
+		})
+
+	return { addTransactionToGroup }
+}

--- a/src/api/mutations/transaction/useRemoveTransactionFromGroup.mutation.ts
+++ b/src/api/mutations/transaction/useRemoveTransactionFromGroup.mutation.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getTransactionsListContract,
+	removeTransactionFromGroupContract,
+	RemoveTransactionFromGroup_ResponsePayload,
+} from 'api/contracts'
+import { RemoveTransactionFromGroup_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useRemoveTransactionFromGroup = (params: RemoveTransactionFromGroup_RouteParams) => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = removeTransactionFromGroupContract
+
+	const RemoveTransactionFromGroup = useMutation({
+			mutationKey: [name],
+			mutationFn: async () =>
+				await api[method]<RemoveTransactionFromGroup_ResponsePayload>(route(params)),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getTransactionsListContract.name] })
+			},
+		})
+
+	return { RemoveTransactionFromGroup }
+}

--- a/src/api/mutations/user/useConfirmUserEmail.mutation.ts
+++ b/src/api/mutations/user/useConfirmUserEmail.mutation.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query'
+
+import {
+	confirmUsersEmailContract,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useConfirmUserEmail = () => {
+	const {name, endpoint: {method, route}} = confirmUsersEmailContract
+
+	const confirmUserEmail = useMutation({
+			mutationKey: [name],
+			mutationFn: async () =>
+				await api[method](route),
+		})
+
+	return { confirmUserEmail }
+}

--- a/src/api/mutations/user/useCreateUser.mutation.ts
+++ b/src/api/mutations/user/useCreateUser.mutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getUsersListContract,
+	createUserContract,
+	CreateUser_RequestPayload,
+	CreateUser_ResponsePayload,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useCreateUserMutation = () => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = createUserContract
+
+	const createUser = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: CreateUser_RequestPayload) =>
+				await api[method]<CreateUser_ResponsePayload>(route, {
+					data,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getUsersListContract.name] })
+			},
+		})
+
+	return { createUser }
+}

--- a/src/api/mutations/user/useDeleteUser.mutation.ts
+++ b/src/api/mutations/user/useDeleteUser.mutation.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getUsersListContract,
+	deleteUserByIdContract,
+} from 'api/contracts'
+import { GetUserById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useDeleteUserByIdMutation = (routeParams: GetUserById_RouteParams) => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = deleteUserByIdContract
+
+	const deleteUser = useMutation({
+			mutationKey: [name],
+			mutationFn: async () =>
+				await api[method](route(routeParams)),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getUsersListContract.name] })
+			},
+		})
+
+	return { deleteUser }
+}

--- a/src/api/mutations/user/useUpdateUser.mutation.ts
+++ b/src/api/mutations/user/useUpdateUser.mutation.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import {
+	getUsersListContract,
+	updateUserByIdContract,
+	UpdateUserById_Request,
+	UpdateUserById_Response,
+} from 'api/contracts'
+import { api } from 'configuration'
+import { GetUserById_RouteParams } from 'api/constants'
+
+export const useUpdateUserMutation = (routeParams: GetUserById_RouteParams) => {
+	const queryClient = useQueryClient()
+	const {name, endpoint: {method, route}} = updateUserByIdContract
+
+	const updateUser = useMutation({
+			mutationKey: [name],
+			mutationFn: async (data: UpdateUserById_Request) =>
+				await api[method]<UpdateUserById_Response>(route(routeParams), {
+					data,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [getUsersListContract.name] })
+			},
+		})
+
+	return { updateUser }
+}


### PR DESCRIPTION
This commit introduces various mutation hooks for CRUD operations across different modules, including auth, group, user, company, addon, and others. These hooks enable managing API interaction using React Query, handling success, error cases, and query invalidation.