### PR TITLE
Add query hooks for API data fetching

### DIFF
--- a/src/api/queries/addon/useGetAddonById.query.ts
+++ b/src/api/queries/addon/useGetAddonById.query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { getAddonByIdContract, GetAddonById_ResponsePayload } from 'api/contracts'
+import { GetAddonById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useGetAddonByIdQuery = (routeParams: GetAddonById_RouteParams) => {
+	const { name, endpoint: {method, route} } = getAddonByIdContract
+
+	const getAddonByIdQuery = useQuery({
+			queryKey: [name, routeParams.addon_id],
+			queryFn: async () =>
+				await api[method]<GetAddonById_ResponsePayload>(route(routeParams))
+		})
+
+	return { getAddonByIdQuery }
+}

--- a/src/api/queries/addon/useGetAddonsList.query.ts
+++ b/src/api/queries/addon/useGetAddonsList.query.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query'
+
+import {
+	getAddonsListContract,
+	GetAddonList_Query,
+	GetAddonList_ResponsePayload,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useGetAddonsListQuery = () => {
+	const { name, endpoint: { method, route } } = getAddonsListContract
+
+	const params: GetAddonList_Query = {
+		limit: 0,
+		offset: 0,
+	}
+	const getAddonsListQuery = useQuery({
+			queryKey: [name],
+			queryFn: async () =>
+				await api[method]<GetAddonList_ResponsePayload>(route, { params })
+		})
+
+	return { getAddonsListQuery, addonsList: getAddonsListQuery.data?.data.results || [] }
+}

--- a/src/api/queries/apiKey/useGetApiKeyById.query.ts
+++ b/src/api/queries/apiKey/useGetApiKeyById.query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { getApiKeyByIdContract, GetApiKeyById_ResponsePayload } from 'api/contracts'
+import { GetApiKeyById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useGetApiKeyByIdQuery = (routeParams: GetApiKeyById_RouteParams) => {
+	const { name, endpoint: {method, route} } = getApiKeyByIdContract
+
+	const getApiKeyById = useQuery({
+			queryKey: [name, routeParams.key_id],
+			queryFn: async () =>
+				await api[method]<GetApiKeyById_ResponsePayload>(route(routeParams))
+		})
+
+	return { getApiKeyById }
+}

--- a/src/api/queries/apiKey/useGetApiKeysList.query.ts
+++ b/src/api/queries/apiKey/useGetApiKeysList.query.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query'
+
+import {
+	getApiKeysListContract,
+	GetApiKeysList_ResponsePayload,
+	GetApiKeysList_RequestQuery,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useGetApiKeysListQuery = () => {
+	const { name, endpoint: { method, route } } = getApiKeysListContract
+
+	const params: GetApiKeysList_RequestQuery = {
+		limit: 0,
+		offset: 0,
+	}
+	const getApiKeysListQuery = useQuery({
+			queryKey: [name],
+			queryFn: async () =>
+				await api[method]<GetApiKeysList_ResponsePayload>(route, { params })
+		})
+
+	return { getApiKeysListQuery, apiKeysList: getApiKeysListQuery.data?.data.results || [] }
+}

--- a/src/api/queries/challengeRule/useGetChallengeRuleById.query.ts
+++ b/src/api/queries/challengeRule/useGetChallengeRuleById.query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { GetChallengeRuleById_ResponsePayload, getChallengeRuleByIdContract } from 'api/contracts'
+import { GetChallengeRuleById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useGetChallengeRuleByIdQuery = (routeParams: GetChallengeRuleById_RouteParams) => {
+	const { name, endpoint: { method, route } } = getChallengeRuleByIdContract
+
+	const getChallengeRuleByIdQuery = useQuery({
+			queryKey: [name, routeParams.challenge_rule_id],
+			queryFn: async () =>
+				await api[method]<GetChallengeRuleById_ResponsePayload>(route(routeParams))
+		})
+
+	return { getChallengeRuleByIdQuery }
+}

--- a/src/api/queries/challengeRule/useGetChallengeRulesList.query.ts
+++ b/src/api/queries/challengeRule/useGetChallengeRulesList.query.ts
@@ -1,0 +1,26 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+
+import { api } from 'configuration'
+import {
+	GetChallengeRulesList_RequestQuery,
+	GetChallengeRulesList_ResponsePayload,
+	getChallengeRulesListContract
+} from 'api/contracts'
+import { AxiosResponse } from 'axios'
+
+export const useGetChallengeRulesListQuery = (params: GetChallengeRulesList_RequestQuery, options?: Omit<UseQueryOptions, 'queryKey' | 'queryFn'>) => {
+	const { name, endpoint: { method, route } } = getChallengeRulesListContract
+
+	console.log(options)
+	const getChallengeRulesListQuery = useQuery<AxiosResponse<GetChallengeRulesList_ResponsePayload>>({
+		queryKey: [name, `Company: ${params.company_id}`, `Limit: ${params.limit}`, `Offset: ${params.offset}`],
+		queryFn: async () =>
+			await api[method](route, { params }),
+	})
+
+	return { getChallengeRulesListQuery, challengeRules: getChallengeRulesListQuery.data?.data.results ?? [] }
+}
+
+// todo type q and m
+// todo pass options as config
+// todo implement behavior extenders

--- a/src/api/queries/challengeType/useGetChallengeTypeById.query.ts
+++ b/src/api/queries/challengeType/useGetChallengeTypeById.query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { GetChallengeTypeById_ResponsePayload, getChallengeTypeByIdContract } from 'api/contracts'
+import { GetChallengeTypeById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useGetChallengeTypeByIdQuery = (routeParams: GetChallengeTypeById_RouteParams) => {
+	const { name, endpoint: { method, route } } = getChallengeTypeByIdContract
+
+	const getChallengeTypeByIdQuery = useQuery({
+			queryKey: [name, routeParams.challenge_type_id],
+			queryFn: async () =>
+				await api[method]<GetChallengeTypeById_ResponsePayload>(route(routeParams))
+		})
+
+	return { getChallengeTypeByIdQuery }
+}

--- a/src/api/queries/challengeType/useGetChallengeTypesList.query.ts
+++ b/src/api/queries/challengeType/useGetChallengeTypesList.query.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { api } from 'configuration'
+import {
+	GetChallengeTypesList_RequestQuery,
+	GetChallengeTypesList_ResponsePayload,
+	getChallengeTypesListContract,
+} from 'api/contracts'
+
+export const useGetChallengeTypesListQuery = () => {
+	const { name, endpoint: { method, route } } = getChallengeTypesListContract
+
+	const params: GetChallengeTypesList_RequestQuery = {
+		limit: 0,
+		offset: 0,
+	}
+
+	const getChallengeTypesListQuery = useQuery({
+			queryKey: [name],
+			queryFn: async () =>
+				await api[method]<GetChallengeTypesList_ResponsePayload>(route, { params })
+		})
+
+	return { getChallengeTypesListQuery, challengeTypesList: getChallengeTypesListQuery.data?.data.results || [] }
+}

--- a/src/api/queries/company/useGetCompanyById.query.ts
+++ b/src/api/queries/company/useGetCompanyById.query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { GetCompanyById_ResponsePayload, getCompanyByIdContract } from 'api/contracts'
+import { GetCompanyById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useGetCompanyByIdQuery = (routeParams: GetCompanyById_RouteParams) => {
+	const { name, endpoint: { method, route } } = getCompanyByIdContract
+
+	const getCompanyByIdQuery = useQuery({
+			queryKey: [name, routeParams.company_id],
+			queryFn: async () =>
+				await api[method]<GetCompanyById_ResponsePayload>(route(routeParams))
+		})
+
+	return { getCompanyByIdQuery }
+}

--- a/src/api/queries/company/useGetCompanyList.query.ts
+++ b/src/api/queries/company/useGetCompanyList.query.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query'
+
+import {
+	getCompaniesListContract,
+	GetCompaniesList_RequestQuery,
+	GetCompaniesList_ResponsePayload
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useGetCompaniesListQuery = () => {
+	const { name, endpoint: { method, route } } = getCompaniesListContract
+
+	const params: GetCompaniesList_RequestQuery = {
+		offset: 0,
+		limit: 10,
+	}
+
+	const getCompaniesListQuery = useQuery({
+			queryKey: [name],
+			queryFn: async () =>
+				await api[method]<GetCompaniesList_ResponsePayload>(route, { params })
+		})
+
+	return { getCompaniesListQuery, companiesList: getCompaniesListQuery.data?.data.results || [] }
+}

--- a/src/api/queries/filter/useGetFilterById.query.ts
+++ b/src/api/queries/filter/useGetFilterById.query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { GetFilterById_ResponsePayload, getFilterByIdContract } from 'api/contracts'
+import { GetFilterById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useGetFilterByIdQuery = (routeParams: GetFilterById_RouteParams) => {
+	const { name, endpoint: { method, route } } = getFilterByIdContract
+
+	const getFilterByIdQuery = useQuery({
+			queryKey: [name, routeParams.filter_id],
+			queryFn: async () =>
+				await api[method]<GetFilterById_ResponsePayload>(route(routeParams))
+		})
+
+	return { getFilterByIdQuery }
+}

--- a/src/api/queries/filter/useGetFilterList.query.ts
+++ b/src/api/queries/filter/useGetFilterList.query.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query'
+
+import {
+	getFiltersListContract,
+	GetFiltersList_RequestQuery,
+	GetFiltersList_ResponsePayload,
+} from 'api/contracts'
+import { api } from 'configuration'
+
+export const useGetFilterListQuery = (params: GetFiltersList_RequestQuery) => {
+	const { name, endpoint: { method, route } } = getFiltersListContract
+
+	const getFiltersListQuery = useQuery({
+			queryKey: [name],
+			queryFn: async () =>
+				await api[method]<GetFiltersList_ResponsePayload>(route, { params })
+		})
+
+	return { getFiltersListQuery }
+}

--- a/src/api/queries/group/useGetGroupById.query.ts
+++ b/src/api/queries/group/useGetGroupById.query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { api } from 'configuration'
+import { GetGroupById_ResponsePayload, getGroupByIdContract } from 'api/contracts'
+import { GetGroupById_RouteParams } from 'api/constants'
+
+export const useGetGroupByIdQuery = (routeParams: GetGroupById_RouteParams) => {
+	const { name, endpoint: { method, route } } = getGroupByIdContract
+
+	const getGroupByIdQuery = useQuery({
+			queryKey: [name, routeParams.group_id],
+			queryFn: async () =>
+				await api[method]<GetGroupById_ResponsePayload>(route(routeParams))
+		})
+
+	return { getGroupByIdQuery }
+}

--- a/src/api/queries/group/useGetGroupsList.query.ts
+++ b/src/api/queries/group/useGetGroupsList.query.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { api } from 'configuration'
+import {
+	GetGroupsList_RequestQuery,
+	GetGroupsList_ResponsePayload,
+	getGroupsListContract,
+} from 'api/contracts'
+
+export const useGetGroupsListQuery = () => {
+	const { name, endpoint: { method, route } } = getGroupsListContract
+
+	const params: GetGroupsList_RequestQuery = {
+		limit: 10,
+		offset: 0
+	}
+
+	const getGroupsListQuery = useQuery({
+			queryKey: [name],
+			queryFn: async () =>
+				await api[method]<GetGroupsList_ResponsePayload>(route, { params })
+		})
+
+	const groupsList = getGroupsListQuery.data?.data.results ?? []
+
+	return { getGroupsListQuery, groupsList }
+}

--- a/src/api/queries/index.ts
+++ b/src/api/queries/index.ts
@@ -1,0 +1,38 @@
+// Addon
+export * from './addon/useGetAddonById.query'
+export * from './addon/useGetAddonsList.query'
+
+// API key
+export * from './apiKey/useGetApiKeyById.query'
+export * from './apiKey/useGetApiKeysList.query'
+
+// Challenge Rule
+export * from './challengeRule/useGetChallengeRuleById.query'
+export * from './challengeRule/useGetChallengeRulesList.query'
+
+// Challenge Type
+export * from './challengeType/useGetChallengeTypesList.query'
+export * from './challengeType/useGetChallengeTypeById.query'
+
+// Company
+export * from './company/useGetCompanyById.query'
+export * from './company/useGetCompanyList.query'
+
+// Filter
+export * from './filter/useGetFilterById.query'
+export * from './filter/useGetFilterList.query'
+
+// Groups
+export * from './group/useGetGroupById.query'
+export * from './group/useGetGroupsList.query'
+
+// Statistic
+export * from './statistics/useGetStatistics.query'
+
+// Transaction
+export * from './transaction/useGetTransactionById.query'
+export * from './transaction/useGetTransactionsList.query'
+
+// User
+export * from './user/useGetUserById.query'
+export * from './user/useGetUsersList.query'

--- a/src/api/queries/statistics/useGetStatistics.query.ts
+++ b/src/api/queries/statistics/useGetStatistics.query.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { getStatisticsContract, GetStatistics_ResponsePayload, GetStatistics_QueryParams } from 'api/contracts'
+import { api } from 'configuration'
+
+export const useGetStatisticsQuery = (params?: GetStatistics_QueryParams) => {
+	const { endpoint: {method, route}, name } = getStatisticsContract
+
+	const getStatistics = useQuery({
+		queryKey: [name],
+		queryFn: async ({}) =>
+			await api[method]<GetStatistics_ResponsePayload>(
+				`${route}?${new URLSearchParams(params).toString()}`,
+				{params}
+			),
+	})
+
+	return {
+		getStatistics,
+	}
+}

--- a/src/api/queries/transaction/useGetTransactionById.query.ts
+++ b/src/api/queries/transaction/useGetTransactionById.query.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { GetTransactionById_ResponsePayload, getTransactionByIdContract } from 'api/contracts'
+import { GetTransactionById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useGetTransactionByIdQuery = (params: GetTransactionById_RouteParams) => {
+	const { name, endpoint: { method, route } } = getTransactionByIdContract
+
+	const getTransactionByIdQuery = useQuery({
+			queryKey: [name, params.transaction_id],
+			queryFn: async () =>
+				await api[method]<GetTransactionById_ResponsePayload>(route(params)),
+
+		})
+
+	return { getTransactionByIdQuery }
+}

--- a/src/api/queries/transaction/useGetTransactionsList.query.ts
+++ b/src/api/queries/transaction/useGetTransactionsList.query.ts
@@ -1,0 +1,43 @@
+'use client'
+
+import {
+	GetTransactionsList_RequestQuery,
+	GetTransactionsList_ResponsePayload,
+	getTransactionsListContract
+} from 'api/contracts'
+import { useQueryParamsController, useTypedQuery } from 'api/hooks'
+import { TanstackQuery_CustomOptions } from 'api/types/request-hook'
+import { api } from 'configuration'
+
+type Options = TanstackQuery_CustomOptions<GetTransactionsList_ResponsePayload>
+
+export const useGetTransactionsListQuery = (
+	options: Options = {}
+) => {
+	const { name, endpoint: { method, route }, defaults } = getTransactionsListContract
+
+	const { additionalQueryKey, ...customOptions } = options
+
+	const queryKey = [name]
+
+	if (additionalQueryKey) queryKey.push(additionalQueryKey)
+
+	const { associateQuery, ...params } = useQueryParamsController<GetTransactionsList_RequestQuery>(defaults.query)
+
+	const query =
+		useTypedQuery<GetTransactionsList_ResponsePayload>({
+			queryKey,
+			queryFn: async () => await api[method](route, { params: params.get() }),
+			...customOptions
+		})
+
+	associateQuery(query)
+
+	return {
+		getTransactionsList: {
+			data: query.data?.data,
+			params,
+			query,
+		}
+	}
+}

--- a/src/api/queries/user/useGetUserById.query.ts
+++ b/src/api/queries/user/useGetUserById.query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { GetUserById_ResponsePayload, getUserByIdContract } from 'api/contracts'
+import { GetUserById_RouteParams } from 'api/constants'
+import { api } from 'configuration'
+
+export const useGetUserByIdQuery = (routeParams: GetUserById_RouteParams) => {
+	const { name, endpoint: { method, route } } = getUserByIdContract
+
+	const getUserByIdQuery = useQuery({
+			queryKey: [name, routeParams.user_id],
+			queryFn: async () =>
+				await api[method]<GetUserById_ResponsePayload>(route(routeParams))
+		})
+
+	return { getUserByIdQuery }
+}

--- a/src/api/queries/user/useGetUsersList.query.ts
+++ b/src/api/queries/user/useGetUsersList.query.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { api } from 'configuration'
+import {
+	GetUsersList_RequestQuery,
+	GetUsersList_ResponsePayload,
+	getUsersListContract
+} from 'api/contracts'
+
+export const useGetUsersListQuery = (query: GetUsersList_RequestQuery) => {
+	const { name, endpoint: { method, route } } = getUsersListContract
+
+	const getUsersListQuery = useQuery({
+			queryKey: [name],
+			queryFn: async () =>
+				await api[method]<GetUsersList_ResponsePayload>(route, { query })
+		})
+
+	return { getUsersListQuery }
+}


### PR DESCRIPTION
Introduce multiple query hooks using `@tanstack/react-query` to simplify API data fetching and management across various entities such as users, groups, transactions, etc. Includes hooks for fetching single records and lists, along with an `index.ts` to export all available queries.