### PR TITLE
Add NotificationBadge, LoadingScreen, and Tab components

### DIFF
--- a/src/components/atoms/LoadingScreen/LoadingScreen.styles.ts
+++ b/src/components/atoms/LoadingScreen/LoadingScreen.styles.ts
@@ -1,0 +1,18 @@
+import { SxProps } from '@mui/material'
+import { Theme } from '@mui/material/styles'
+
+const container: SxProps<Theme> = {
+	display: 'flex',
+	justifyContent: 'center',
+	alignItems: 'center',
+	flexDirection: 'column',
+	height: '100vh',
+	zIndex: 999999,
+	position: 'absolute',
+	inset: 0,
+	backgroundColor: 'white',
+} as const
+
+export default {
+	container
+}

--- a/src/components/atoms/LoadingScreen/LoadingScreen.tsx
+++ b/src/components/atoms/LoadingScreen/LoadingScreen.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography, Fade } from '@mui/material'
+
+import {projectName} from 'configuration/constants'
+
+import style from './LoadingScreen.styles'
+
+interface LoadingScreenProps {
+	show: boolean
+}
+
+export const LoadingScreen = ({show}: LoadingScreenProps) => {
+	return (
+		<Fade in={show} appear={false} timeout={300}>
+			<Box sx={style.container}>
+				<Typography variant="h1">{projectName}</Typography>
+				<Typography variant="h5" color="textDisabled">Loading</Typography>
+			</Box>
+		</Fade>
+	)
+}

--- a/src/components/atoms/NotificationBadge/NotificationBadge.styles.ts
+++ b/src/components/atoms/NotificationBadge/NotificationBadge.styles.ts
@@ -1,0 +1,16 @@
+import {SxProps} from "@mui/material";
+import {Theme} from "@mui/material/styles";
+
+const container: SxProps<Theme> = {
+    height: 8,
+    width: 8,
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    borderRadius: '50%',
+    backgroundColor: theme => theme.palette.warning.main,
+} as const
+
+export default {
+    container,
+}

--- a/src/components/atoms/NotificationBadge/NotificationBadge.tsx
+++ b/src/components/atoms/NotificationBadge/NotificationBadge.tsx
@@ -1,0 +1,12 @@
+import style from './NotificationBadge.styles'
+import { Box, BoxProps } from '@mui/material'
+
+interface NotificationBadgeProps extends BoxProps {
+    show: boolean
+}
+
+export const NotificationBadge = ({show = false, ...boxProps}: NotificationBadgeProps) => {
+    if (!show) return null
+
+    return <Box sx={[style.container]}/>
+}

--- a/src/components/atoms/Tab/Tab.styles.ts
+++ b/src/components/atoms/Tab/Tab.styles.ts
@@ -1,0 +1,39 @@
+import {SxProps} from "@mui/material";
+import {Theme} from "@mui/material/styles";
+
+const container: SxProps<Theme> = {
+    position: 'relative',
+    backgroundColor: theme => theme.palette.primary.main,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+    width: '100%',
+    color: theme => theme.palette.primary.contrastText,
+    textTransform: 'uppercase',
+    cursor: 'pointer',
+
+    '&:hover': {
+        backgroundColor: theme => theme.palette.primary.dark,
+    }
+} as const
+
+const active: SxProps<Theme> = {
+    backgroundColor: theme => theme.palette.warning.main,
+} as const
+
+const notification: SxProps<Theme> = {
+    height: 8,
+    width: 8,
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    borderRadius: '50%',
+    backgroundColor: theme => theme.palette.warning.main,
+} as const
+
+export default {
+    container,
+    notification,
+	active,
+}

--- a/src/components/atoms/Tab/Tab.tsx
+++ b/src/components/atoms/Tab/Tab.tsx
@@ -1,0 +1,19 @@
+import { Box, BoxProps, Typography } from '@mui/material'
+
+import style from './Tab.styles'
+import {NotificationBadge} from "../NotificationBadge/NotificationBadge";
+
+interface TabProps extends BoxProps{
+    label: string;
+    notification: boolean;
+    isActive: boolean;
+}
+
+export const Tab = ({label, notification, isActive, ...boxProps}: TabProps) => {
+    return (
+        <Box sx={[style.container, isActive && style.active]} {...boxProps}>
+            <NotificationBadge show={notification}/>
+            <Typography>{label}</Typography>
+        </Box>
+    )
+}

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,0 +1,3 @@
+export * from './LoadingScreen/LoadingScreen'
+export * from './NotificationBadge/NotificationBadge'
+export * from './Tab/Tab'


### PR DESCRIPTION
Introduced reusable atom components: NotificationBadge, LoadingScreen, and Tab, with their respective styles. These additions enhance UI modularity and facilitate consistent design. Updated index.ts to export these new components.