### PR TITLE
Add global providers for modals, themes, banners, and toast

### DIFF
--- a/src/configuration/Providers/BannerProvider/BannerProvider.tsx
+++ b/src/configuration/Providers/BannerProvider/BannerProvider.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { Box } from '@mui/material'
+import { Fragment, ReactNode, useMemo } from 'react'
+
+import { ApiKeyBanner } from 'components/organisms'
+
+export const BannerProvider = () => {
+	const content = useMemo(() => {
+		const result: ReactNode[] = []
+
+		// TODO: Remove when other banners are in place
+		if (false) result.push(<ApiKeyBanner key="demoBanner" />)
+		return result
+
+		// TODO: Remove when other banners are in place
+		return [<Fragment key={'no banner'}></Fragment>]
+	}, [])
+
+	if (content.length === 0) return null
+
+	return <Box>{content}</Box>
+}

--- a/src/configuration/Providers/ModalProvider/ModalProvider.tsx
+++ b/src/configuration/Providers/ModalProvider/ModalProvider.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { CreateGroupModal, AddApiKeyModal } from 'components/organisms'
+import { MODAL_TYPE, useModal } from 'configuration/store'
+
+/**
+ * This component render modals, globally available in application
+ * FYI: conditional rendering is needed to prevent extra components render, and their logic execution
+ */
+export const ModalProvider = () => {
+	const { modal: { type } } = useModal()
+
+	return (
+		<>
+			{type === MODAL_TYPE.CREATE_GROUP && <CreateGroupModal />}
+			{type === MODAL_TYPE.ADD_API_KEY && <AddApiKeyModal />}
+		</>
+	)
+}

--- a/src/configuration/Providers/Providers.tsx
+++ b/src/configuration/Providers/Providers.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import createCache from '@emotion/cache'
+import { CacheProvider } from '@emotion/react'
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { ReactNode } from 'react'
+import { Provider as StoreProvider } from 'react-redux'
+
+import { store } from 'configuration/store'
+
+import { BannerProvider } from './BannerProvider/BannerProvider'
+import { ModalProvider } from './ModalProvider/ModalProvider'
+import { TanstackProvider } from './TanstackProvider/TanstackProvider'
+import { ThemeProvider } from './ThemeProvider/ThemeProvider'
+import { ToastProvider } from './ToastProvider/ToastProvider'
+import { CssBaseline } from '@mui/material'
+
+const clientSideEmotionCache = createCache({ key: 'css', prepend: true })
+
+export const Providers = ({ children }: { children: ReactNode }) => {
+	return (
+		<AppRouterCacheProvider options={{ enableCssLayer: true }}>
+			<StoreProvider store={store}>
+				<TanstackProvider>
+					<CacheProvider value={clientSideEmotionCache}>
+						<ReactQueryDevtools initialIsOpen={false} />
+						<CssBaseline/>
+						<ThemeProvider>
+							<BannerProvider />
+							<ToastProvider />
+							<ModalProvider />
+							{children}
+						</ThemeProvider>
+					</CacheProvider>
+				</TanstackProvider>
+			</StoreProvider>
+		</AppRouterCacheProvider>
+	)
+}

--- a/src/configuration/Providers/TanstackProvider/TanstackProvider.tsx
+++ b/src/configuration/Providers/TanstackProvider/TanstackProvider.tsx
@@ -1,0 +1,19 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import { useCreateTanstackClient } from 'hooks'
+
+interface TanstackProviderProps {
+	children: React.ReactNode
+}
+
+export const TanstackProvider = ({ children }: TanstackProviderProps) => {
+	const { createTanstackClient } = useCreateTanstackClient()
+
+	const browserClient = useMemo(() => createTanstackClient(), [createTanstackClient])
+
+	return (
+		<QueryClientProvider client={browserClient}>
+			{children}
+		</QueryClientProvider>
+	)
+}

--- a/src/configuration/Providers/ThemeProvider/ThemeProvider.hooks.ts
+++ b/src/configuration/Providers/ThemeProvider/ThemeProvider.hooks.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react'
+import { ThemeContext } from './ThemeProvider'
+
+export const useThemeProvider = (): ThemeContext => {
+	const context = useContext(ThemeContext)
+
+	if (!context) {
+		throw new Error('useThemeControls hook must be used within a Theme context')
+	}
+
+	return context
+}

--- a/src/configuration/Providers/ThemeProvider/ThemeProvider.tsx
+++ b/src/configuration/Providers/ThemeProvider/ThemeProvider.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import {
+	PaletteMode,
+	ThemeProvider as MUI_ThemeProvider,
+	useMediaQuery,
+	CssBaseline,
+	GlobalStyles,
+} from '@mui/material'
+import { createContext, ReactNode, useCallback, useLayoutEffect, useMemo, useState } from 'react'
+
+import { localStorageKey } from 'configuration/constants'
+import { globalStyles, theme } from 'configuration/styles'
+
+export type THEME_MODE = 'light' | 'dark'
+
+export interface ThemeContext {
+	themeMode: THEME_MODE
+	toggleThemeMode: () => void
+}
+
+export const ThemeContext = createContext({} as ThemeContext)
+
+interface ThemeProviderProps {
+	children: ReactNode
+}
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
+	const [mode, setMode] = useState<PaletteMode>('light')
+	const systemInDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
+
+	useLayoutEffect(() => {
+		const preferSystemTheme = false // Use a value from profile settings, when implemented
+
+		if (preferSystemTheme) {
+			localStorage.setItem(localStorageKey.theme, systemInDarkMode ? 'dark' : 'light')
+			setMode(systemInDarkMode ? 'dark' : 'light')
+			return
+		}
+
+		const modes: PaletteMode[] = ['light', 'dark']
+		const recoveredTheme = (localStorage.getItem(localStorageKey.theme) as PaletteMode) ?? 'light'
+
+		if (modes.includes(recoveredTheme)) setMode(recoveredTheme)
+		else {
+			setMode('light')
+			localStorage.setItem(localStorageKey.theme, 'light')
+		}
+	}, [systemInDarkMode])
+
+	const toggleThemeMode = useCallback(() => {
+		const newMode = mode === 'light' ? 'dark' : 'light'
+
+		setMode(newMode)
+		localStorage.setItem(localStorageKey.theme, newMode)
+	}, [mode])
+
+	const contextValue = useMemo<ThemeContext>(
+		() => ({
+			toggleThemeMode,
+			themeMode: mode,
+		}),
+		[mode, toggleThemeMode],
+	)
+
+	return (
+		<ThemeContext.Provider value={contextValue}>
+			<MUI_ThemeProvider theme={theme(mode)}>
+				<CssBaseline />
+				<GlobalStyles styles={globalStyles} />
+				{children}
+			</MUI_ThemeProvider>
+		</ThemeContext.Provider>
+	)
+}

--- a/src/configuration/Providers/ToastProvider/ToastProvider.tsx
+++ b/src/configuration/Providers/ToastProvider/ToastProvider.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { Alert, Snackbar, Slide, AlertTitle } from '@mui/material'
+
+import { useToast } from 'configuration/store'
+
+export const ToastProvider = () => {
+	const {
+		toast: { open, type, title, duration, message },
+		hideToast,
+		resetToastParams,
+	} = useToast()
+
+	return (
+		<Snackbar
+			open={open}
+			onClose={hideToast}
+			autoHideDuration={duration}
+			TransitionComponent={Slide}
+			TransitionProps={{
+				onExited: resetToastParams,
+			}}
+			anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+		>
+			<Alert severity={type}>
+				{title && <AlertTitle>{title}</AlertTitle>}
+				{message}
+			</Alert>
+		</Snackbar>
+	)
+}

--- a/src/configuration/Providers/index.ts
+++ b/src/configuration/Providers/index.ts
@@ -1,0 +1,11 @@
+export * from './Providers'
+
+export * from './BannerProvider/BannerProvider'
+
+export * from './ModalProvider/ModalProvider'
+
+export * from './ThemeProvider/ThemeProvider'
+export * from './ThemeProvider/ThemeProvider.hooks'
+
+export * from './ToastProvider/ToastProvider'
+export * from './ThemeProvider/ThemeProvider.hooks'


### PR DESCRIPTION
This commit introduces several providers, including `ModalProvider`, `ThemeProvider`, `BannerProvider`, `TanstackProvider`, and `ToastProvider` to manage global application states and render UI elements. These providers centralize the handling of modals, theme modes, toast notifications, banners, and TanStack Query setups, ensuring