### PR TITLE
Add Redux store structure and slice implementations

### DIFF
--- a/src/configuration/store/App.store.ts
+++ b/src/configuration/store/App.store.ts
@@ -1,0 +1,29 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import { combineReducers } from 'redux'
+
+import { appSlice } from './app/app.slice'
+import { currentUserSlice } from './currentUser/currentUser.slice'
+import { modalSlice } from './modal/modal.slice'
+import { toastSlice } from './toast/toast.slice'
+
+const reducer = combineReducers({
+	app: appSlice.reducer,
+	modal: modalSlice.reducer,
+	toast: toastSlice.reducer,
+	currentUser: currentUserSlice.reducer,
+})
+
+export const store = configureStore({
+	reducer,
+	middleware: (getDefaultMiddleware) =>
+		getDefaultMiddleware({
+			serializableCheck: false
+		})
+})
+
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch
+
+export const useAppDispatch: () => AppDispatch = useDispatch
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/src/configuration/store/app/app.hooks.ts
+++ b/src/configuration/store/app/app.hooks.ts
@@ -1,0 +1,25 @@
+import {
+	openLeftDrawer,
+	closeLeftDrawer,
+	closeRightDrawer,
+	openRightDrawer,
+	hideLoader,
+	showLoader,
+	setLoggedIn,
+} from './app.slice'
+import { RootState, useAppDispatch, useAppSelector } from '../App.store'
+
+export const useAppConfig = () => {
+	const dispatch = useAppDispatch()
+
+	return {
+		openLeftDrawer: () => dispatch(openLeftDrawer()),
+		closeLeftDrawer: () => dispatch(closeLeftDrawer()),
+		closeRightDrawer: () => dispatch(closeRightDrawer()),
+		openRightDrawer: () => dispatch(openRightDrawer()),
+		hideLoader: () => dispatch(hideLoader()),
+		setLoggedIn: (isLoggedIn: boolean) => dispatch(setLoggedIn(isLoggedIn)),
+		showLoader: () => dispatch(showLoader()),
+		selectAppState: useAppSelector((state: RootState) => state.app)
+	}
+}

--- a/src/configuration/store/app/app.slice.ts
+++ b/src/configuration/store/app/app.slice.ts
@@ -1,0 +1,61 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+export interface AppState {
+	loggedIn: boolean
+	showLeftDrawer: boolean
+	showRightDrawer: boolean
+	showLoader: boolean
+}
+
+const initialState: AppState = {
+	loggedIn: false,
+	showLeftDrawer: false,
+	showRightDrawer: false,
+	showLoader: false
+}
+
+export const appSlice = createSlice({
+	name: 'App',
+	initialState,
+	reducers: {
+		openLeftDrawer: (state): AppState => ({
+			...state,
+			showLeftDrawer: true
+		}),
+		closeLeftDrawer: (state): AppState => ({
+			...state,
+			showLeftDrawer: false
+		}),
+		setLoggedIn: (state, action: PayloadAction<boolean>): AppState => ({
+			...state,
+			loggedIn: action.payload
+		}),
+		openRightDrawer: (state): AppState => ({
+			...state,
+			showRightDrawer: true
+		}),
+		closeRightDrawer: (state): AppState => ({
+			...state,
+			showRightDrawer: false
+		}),
+		showLoader: (state): AppState => ({
+			...state,
+			showLoader: true
+		}),
+		hideLoader: (state): AppState => ({
+			...state,
+			showLoader: false
+		})
+	}
+})
+
+export const {
+	openLeftDrawer,
+	closeLeftDrawer,
+	openRightDrawer,
+	closeRightDrawer,
+	showLoader,
+	hideLoader,
+	setLoggedIn
+} =
+	appSlice.actions

--- a/src/configuration/store/currentUser/currentUser.hooks.ts
+++ b/src/configuration/store/currentUser/currentUser.hooks.ts
@@ -1,0 +1,15 @@
+import { RootState, useAppDispatch, useAppSelector } from 'configuration/store'
+
+import { User } from 'api/schemas'
+
+import { clearCurrentUser, setCurrentUser } from './currentUser.slice'
+
+export const useCurrentUser = () => {
+	const dispatch = useAppDispatch()
+
+	return {
+		clearCurrentUser: () => dispatch(clearCurrentUser()),
+		setCurrentUser: (user: User) => dispatch(setCurrentUser(user)),
+		currentUser: useAppSelector((state: RootState) => state.currentUser),
+	}
+}

--- a/src/configuration/store/currentUser/currentUser.slice.ts
+++ b/src/configuration/store/currentUser/currentUser.slice.ts
@@ -1,0 +1,21 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+
+import { User } from 'api/schemas'
+
+type CurrentUserState = Partial<User>
+
+const initialState: CurrentUserState = {}
+
+export const currentUserSlice = createSlice({
+	name: 'currentUser',
+	initialState,
+	reducers: {
+		setCurrentUser: (_, action: PayloadAction<User>): User => ({
+			...action.payload,
+		}),
+		clearCurrentUser: (): CurrentUserState => initialState,
+	},
+})
+
+export const { setCurrentUser, clearCurrentUser } =
+	currentUserSlice.actions

--- a/src/configuration/store/index.ts
+++ b/src/configuration/store/index.ts
@@ -1,0 +1,12 @@
+// Store
+export * from './App.store'
+
+// Hooks
+export * from './app/app.hooks'
+export * from './app/app.slice'
+export * from './currentUser/currentUser.hooks'
+export * from './currentUser/currentUser.slice'
+export * from './modal/modal.hooks'
+export * from './modal/modal.slice'
+export * from './toast/toast.hooks'
+export * from './toast/toast.slice'

--- a/src/configuration/store/modal/modal.hooks.ts
+++ b/src/configuration/store/modal/modal.hooks.ts
@@ -1,0 +1,15 @@
+import { openCreateGroupModal, RootState, useAppDispatch, useAppSelector } from 'configuration/store'
+
+import { closeModal, resetModalParams, openAddApiKeyModal } from './modal.slice'
+
+export const useModal = () => {
+	const dispatch = useAppDispatch()
+
+	return {
+		closeModal: () => dispatch(closeModal()),
+		openCreateGroupModal: () => dispatch(openCreateGroupModal()),
+		openAddApiKeyModal: () => dispatch(openAddApiKeyModal()),
+		resetModalParams: () => dispatch(resetModalParams()),
+		modal: useAppSelector((state: RootState) => state.modal),
+	}
+}

--- a/src/configuration/store/modal/modal.slice.ts
+++ b/src/configuration/store/modal/modal.slice.ts
@@ -1,0 +1,57 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+export enum MODAL_TYPE {
+	SIMPLE = 'Simple modal',
+	ADD_API_KEY = 'Add API key modal',
+	CREATE_GROUP = 'Create Group modal',
+	FULLSCREEN = 'Fullscreen modal',
+	CREATE_CATEGORY = 'Create Category modal',
+	CLOSED = 'Closed',
+}
+
+export interface ModalState {
+	isClosingNow: boolean
+	type: MODAL_TYPE
+	props?: undefined
+}
+
+const initialState: ModalState = {
+	isClosingNow: false,
+	type: MODAL_TYPE.CLOSED,
+	props: undefined,
+}
+
+export const modalSlice = createSlice({
+	name: 'modal',
+	initialState,
+	reducers: {
+		/** Initiates modal closing procedure. Required to give animation time to finish.*/
+		closeModal: (state): ModalState => ({
+			...state,
+			isClosingNow: true,
+		}),
+		openCreateGroupModal: (state): ModalState => ({
+			...state,
+			type: MODAL_TYPE.CREATE_GROUP,
+		}),
+		openAddApiKeyModal: (state): ModalState => ({
+			...state,
+			type: MODAL_TYPE.ADD_API_KEY,
+		}),
+		/** Finalizes modal closing procedure. Required to ensure, no props persist between modals.*/
+		resetModalParams: (): ModalState => initialState,
+	},
+})
+
+export const { closeModal, resetModalParams, openCreateGroupModal, openAddApiKeyModal } =
+	modalSlice.actions
+
+/*
+Calling modal with props action example
+
+openAuthModal: (state, action: PayloadAction<AuthModalProps>): ModalState => ({
+			...state,
+			type: MODAL_TYPE.AUTH,
+			props: action.payload,
+		}),
+*/

--- a/src/configuration/store/toast/toast.hooks.ts
+++ b/src/configuration/store/toast/toast.hooks.ts
@@ -1,0 +1,16 @@
+import { RootState, useAppDispatch, useAppSelector } from 'configuration/store'
+
+import { hideToast, resetToastParams, showToast, OpenToastAction } from './toast.slice'
+
+export const useToast = () => {
+	const dispatch = useAppDispatch()
+
+	return {
+		hideToast: () => dispatch(hideToast()),
+		resetToastParams: () => dispatch(resetToastParams()),
+		showToast: (payload: OpenToastAction) => dispatch(showToast(payload)),
+		toast: useAppSelector((state: RootState) => state.toast),
+	}
+}
+
+// TODO: Toast dont hide automatically

--- a/src/configuration/store/toast/toast.slice.ts
+++ b/src/configuration/store/toast/toast.slice.ts
@@ -1,0 +1,44 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+
+import type { AlertColor } from '@mui/material'
+
+export interface ToastState {
+	open: boolean
+	message: string
+	title?: string
+	type?: AlertColor
+	duration?: number | null
+}
+
+const toastDefaultParams: Required<ToastState> = {
+	open: false,
+	message: '',
+	title: '',
+	type: 'info',
+	duration: 2000,
+}
+
+const initialState: ToastState = {
+	...toastDefaultParams,
+}
+
+export type OpenToastAction = Omit<ToastState, 'open'>
+
+export const toastSlice = createSlice({
+	name: 'toast',
+	initialState,
+	reducers: {
+		hideToast: (state): ToastState => ({
+			...state,
+			open: false,
+		}),
+		resetToastParams: (): ToastState => initialState,
+		showToast: (_, action: PayloadAction<OpenToastAction>): ToastState => ({
+			...action.payload,
+			open: true,
+		}),
+	},
+})
+
+export const { hideToast, showToast, resetToastParams } =
+	toastSlice.actions


### PR DESCRIPTION
Establishes a Redux store structure with slices for app, modal, toast, and current user states. Includes related hooks for accessing and dispatching actions, enabling modular state management.